### PR TITLE
Order shipping admin

### DIFF
--- a/upload/admin/controller/extension/shipping/inpostoc3.php
+++ b/upload/admin/controller/extension/shipping/inpostoc3.php
@@ -737,7 +737,7 @@ class ControllerExtensionShippingInPostOC3 extends Controller {
 
     // for AJAX calls and dynamic dropdown filling
     // sendingMethods: expecting ?route=extension/shipping/inpostoc3/sendingmethods&service_id=1&user_token=...
-    public function sendingMethods() {
+    public function sendingMethodsForService() {
         $json = array();
 
         if ( !isset($this->request->get['service_id']) ) {
@@ -768,6 +768,32 @@ class ControllerExtensionShippingInPostOC3 extends Controller {
         $this->response->setOutput(json_encode($json));
     }
 
+    // get details of specific sending method
+    public function sendingMethod() {
+        $json = array();
+
+        if ( !isset($this->request->get['sending_method_id']) || $this->request->get['sending_method_id'] == 0 ) {
+            $json['error']['warning'] = $this->language->get('error_no_sending_method');
+        } else {
+            $this->load->model('extension/shipping/inpostoc3');
+            $this->load->language('extension/shipping/inpostoc3');
+
+            $filter['id'] = $this->request->get['sending_method_id'];
+            $sending_methods = $this->model_extension_shipping_inpostoc3->getSendingMethods($filter);
+            $sending_method = $sending_methods[0]; // dereference from multi-row structure
+            if ( !empty($sending_method) ) {
+                $sending_method['description'] = $this->language->get('text_sending_method_' . $sending_method['sending_method_identifier'] );
+                $json['sending_method'] = $sending_method;
+            } else {
+                $json['error']['warning'] = $this->language->get('error_no_sending_method');
+            }
+            
+        }
+
+        $this->response->addHeader('Content-Type: application/json');
+        $this->response->setOutput(json_encode($json));
+    }
+    
     // senders: expecting ?route=extension/shipping/inpostoc3/senders&sender_id=1&user_token=...
     public function senders() {
         $json = array();

--- a/upload/admin/controller/extension/shipping/inpostoc3.php
+++ b/upload/admin/controller/extension/shipping/inpostoc3.php
@@ -362,12 +362,13 @@ class ControllerExtensionShippingInPostOC3 extends Controller {
 
         $this->load->model('extension/shipping/inpostoc3');
         $inpost_services = $this->model_extension_shipping_inpostoc3->getServicesWithAssocAttributes();
-        // expose variable for template
-        $data['inpost_services'] =  $inpost_services;  
         
+        // expose variable for template
+        $data['inpost_services'] =  $inpost_services;    
+        //TODO replace/remove below flags once shipment parsing done      
         $data["inpostoc3_can_edit"]["shipment"] = true;
         $data["inpostoc3_can_edit"]["sending_method_details"] = true;
-        // TODO: check later if it is not present or in draft status
+
 
         if( isset($this->request->get['order_id']) ) {
             
@@ -380,15 +381,155 @@ class ControllerExtensionShippingInPostOC3 extends Controller {
                 $shipping_code_details = explode('.',$shipping_code);
                 $this->fillDataWithDetailsFromShippingCodeDetails($shipping_code_details, $data);
 
+                // prep order data and receiver data
+                $this->load->model('sale/order');
+                $order_info = $this->model_sale_order->getOrder($this->request->get['order_id']);
+                $this->load->model('localisation/country');
+
+                if (!empty($order_info)) {
+                    $data['store_id'] = $order_info['store_id'];
+                    $data['store_url'] = $this->request->server['HTTPS'] ? HTTPS_CATALOG : HTTP_CATALOG;
+        
+                    $data['receiver']['name'] = $order_info['customer'].' (#'.$order_info['customer_id'].')';
+                    //$data['customer_id'] = $order_info['customer_id'];
+                    //$data['customer_group_id'] = $order_info['customer_group_id'];
+                    //$data['firstname'] = $order_info['firstname'];
+                    //$data['lastname'] = $order_info['lastname'];
+                    $data['receiver']['email'] = $order_info['email'];
+                    $data['receiver']['phone'] = $order_info['telephone'];
+                    //$data['account_custom_field'] = $order_info['custom_field'];
+        
+                    //$this->load->model('customer/customer');
+        
+                    //$data['addresses'] = $this->model_customer_customer->getAddresses($order_info['customer_id']);
+
+                    $data['receiver']['first_name'] = $order_info['shipping_firstname'];
+                    $data['receiver']['last_name'] = $order_info['shipping_lastname'];
+                    $data['receiver']['company_name'] = $order_info['shipping_company'];
+                    $data['receiver']['line1'] = $order_info['shipping_address_1'];
+                    $data['receiver']['line2'] = $order_info['shipping_address_2'];
+                    $data['receiver']['city'] = $order_info['shipping_city'];
+                    $data['receiver']['post_code'] = $order_info['shipping_postcode'];
+
+                    $country = $this->model_localisation_country->getCountry( (int)$order_info['shipping_country_id'] );
+                    $data['receiver']['country_iso_code_2'] = $country['iso_code_2'];
+                    $data['receiver']['country_iso_code_3'] = $country['iso_code_3'];
+
+                    //$data['shipping_country_id'] = $order_info['shipping_country_id'];
+                    //$data['shipping_zone_id'] = $order_info['shipping_zone_id'];
+                    //$data['shipping_custom_field'] = $order_info['shipping_custom_field'];
+                    //$data['shipping_method'] = $order_info['shipping_method'];
+                    //$data['shipping_code'] = $order_info['shipping_code'];
+
+                    // Products - assign products to a parcel for multiparcel shipments (FUTURE TODO)
+                    $data['order_products'] = array();
+
+                    $products = $this->model_sale_order->getOrderProducts($this->request->get['order_id']);
+
+                    foreach ($products as $product) {
+                        $data['order_products'][] = array(
+                            'product_id' => $product['product_id'],
+                            'name'       => $product['name'],
+                            'model'      => $product['model'],
+                            'option'     => $this->model_sale_order->getOrderOptions($this->request->get['order_id'], $product['order_product_id']),
+                            'quantity'   => $product['quantity'],
+                            'price'      => $product['price'],
+                            'total'      => $product['total'],
+                            'reward'     => $product['reward']
+                        );
+                    }
+
+                    $data['order_status_id'] = $order_info['order_status_id'];
+                    $data['comment'] = $order_info['comment'];
+                    $data['affiliate_id'] = $order_info['affiliate_id'];
+                    $data['affiliate'] = $order_info['affiliate_firstname'] . ' ' . $order_info['affiliate_lastname'];
+                    $data['currency_code'] = $order_info['currency_code'];
+                     
+                } else {
+                    $data['store_id'] = 0;
+                    $data['store_url'] = $this->request->server['HTTPS'] ? HTTPS_CATALOG : HTTP_CATALOG;
+                    
+                    /*
+                    $data['customer'] = '';
+                    $data['customer_id'] = '';
+                    $data['customer_group_id'] = $this->config->get('config_customer_group_id');
+                    $data['firstname'] = '';
+                    $data['lastname'] = '';
+                    $data['email'] = '';
+                    $data['telephone'] = '';
+                    $data['customer_custom_field'] = array();
+                    
+                    $data['addresses'] = array();
+                    
+                    $data['shipping_firstname'] = '';
+                    $data['shipping_lastname'] = '';
+                    $data['shipping_company'] = '';
+                    $data['shipping_address_1'] = '';
+                    $data['shipping_address_2'] = '';
+                    $data['shipping_city'] = '';
+                    $data['shipping_postcode'] = '';
+                    $data['shipping_country_id'] = '';
+                    $data['shipping_zone_id'] = '';
+                    $data['shipping_custom_field'] = array();
+                    $data['shipping_method'] = '';
+                    $data['shipping_code'] = '';
+                    */ 
+
+                    $data['receiver']['name'] = '';
+                    $data['receiver']['email'] = '';
+                    $data['receiver']['phone'] = '';
+                    $data['receiver']['first_name'] = '';
+                    $data['receiver']['last_name'] = '';
+                    $data['receiver']['company_name'] = '';
+                    $data['receiver']['line1'] = '';
+                    $data['receiver']['line2'] = '';
+                    $data['receiver']['city'] = '';
+                    $data['receiver']['post_code'] = '';
+                    $data['receiver']['country_iso_code_2'] = '';
+                    $data['receiver']['country_iso_code_3'] = '';
+
+                    $data['order_products'] = array();
+
+                    $data['order_status_id'] = $this->config->get('config_order_status_id');
+                    $data['comment'] = '';
+                    $data['affiliate_id'] = '';
+                    $data['affiliate'] = '';
+                    $data['currency_code'] = $this->config->get('config_currency');
+                }
+
+                $this->load->model('setting/setting');
+
+                if ($order_info && $order_info['shipping_code']) {
+                    $store_info = $this->model_setting_setting->getSetting('config', $order_info['store_id']);
+                    
+                    if ($store_info) {
+                        $data["sender"]["company_name"] = $store_info["config_owner"];
+                        $data["sender"]["email"] = $store_info['config_email'];
+                        $data["sender"]["phone"] = $store_info['config_telephone'];
+                    } else {
+                        $data["sender"]["company_name"] = $this->config->get('config_owner');
+                        $data["sender"]["email"] = $this->config->get('config_email');
+                        $data["sender"]["phone"] = $this->config->get('config_telephone');
+                    }
+                    $find['id'] = $this->config->get('shipping_inpostoc3_' . $data['shipping_code_inpostoc3_geo_zone_id'] . '_' . $data['shipping_code_inpostoc3_service_id'] . '_sendfrom');
+                    $find['result'] = $this->model_extension_shipping_inpostoc3->getRoutes($find);
+                    $this->log->write(__METHOD__ .' $find: ' . print_r($find,true)); 
+                    if (count($find['result'] ) == 1) {
+                        $data["sender"]["country_iso_code_2"] = $find['result'][0]['sender_country_iso_code_2'];
+                        $data["sender"]["country_iso_code_3"] = $find['result'][0]['sender_country_iso_code_3'];
+                    }  
+                }
+
                 $filter['order_id'] = $data['order_id'];
                 $data['shipments'] = $this->model_extension_shipping_inpostoc3->getShipments($filter);
-                $this->log->write('Got shipments: ' . print_r($data['shipments'],true));
+                //$this->log->write('Got shipments: ' . print_r($data['shipments'],true));
                 if ( empty($data['shipments']) || !isset($data['shipments']) ) {
                     // means no draft stuff was even created, need to save one before serving the view
                     $new_shipment['status'] = 'draft';
                     $new_shipment['order_id'] = $data['order_id'];
                     $new_shipment['service_id'] = $data['shipping_code_inpostoc3_service_id'];
-                    // add receiver_id from order data
+                    $new_shipment['receiver'] = $data['receiver'];
+                    $new_shipment['sender'] = $data['sender'];
                     $new_shipment['parcels'][0]['template_id'] = $data['shipping_code_inpostoc3_parcel_template_id'];
                     $new_shipment['custom_attributes']['target_point'] = $data['shipping_code_inpostoc3_target_point'];
                     //$this->log->write(__METHOD__ . 'New shipment: ' . print_r($new_shipment,true));
@@ -396,18 +537,20 @@ class ControllerExtensionShippingInPostOC3 extends Controller {
                         $new_shipment['id'] = $this->model_extension_shipping_inpostoc3->createShipment($new_shipment);
                         $filter['order_id'] = $data['order_id']; //just in case
                         $data['shipments'] = $this->model_extension_shipping_inpostoc3->getShipments($filter);
-                        $this->log->write(__METHOD__ .' Created new shipment, $data[\'shipments\']: ' . print_r($data['shipments'],true));     
-                    }     
+                        //$this->log->write(__METHOD__ .' Created new shipment, $data[\'shipments\']: ' . print_r($data['shipments'],true));     
+                    }
                 }
                 
+                // can edit shipment, fill in receiver & sender if empty
                 foreach ( $data['shipments'] as $o_shipment ) {
                     if ($o_shipment['status'] == 'draft' ) {
                         $data['shipments'][$o_shipment['id']]['can_edit']['sending_method_details'] = true;
                     } else {
                         $data['shipments'][$o_shipment['id']]['can_edit']['sending_method_details'] = false;
                     }
+                    empty($data['shipments'][$o_shipment['id']]['receiver']) ? $data['shipments'][$o_shipment['id']]['receiver'] = $data['receiver'] : '';
+                    empty($data['shipments'][$o_shipment['id']]['sender']) ? $data['shipments'][$o_shipment['id']]['sender'] = $data['sender'] : '';
                 }
-                
 
                 
                 /*foreach( $data['inpostoc3_services'] as $service ) {
@@ -691,12 +834,14 @@ class ControllerExtensionShippingInPostOC3 extends Controller {
             // hate to reload model multiple times, anyway to set it once as a class property?
             $this->load->model('extension/shipping/inpostoc3');
             $data['shipping_code_inpostoc3_service_identifier'] = $this->model_extension_shipping_inpostoc3->getServiceIdentifier($service_details[1]);
-            $data['shipping_code_inpostoc3_parcel_template_identifier'] = $service_details[2];
-            $filter['service_id'] = $data['shipping_code_inpostoc3_service_id'];
-            $filter['template_identifier'] = $data['shipping_code_inpostoc3_parcel_template_identifier'];
-            $pt = $this->model_extension_shipping_inpostoc3->getParcelTemplates($filter); // for this $filter setup there must be only one
-            
-            $data['shipping_code_inpostoc3_parcel_template_id'] = $pt[0]['id'];
+            ( !empty($service_details[2]) ) ? $data['shipping_code_inpostoc3_parcel_template_identifier'] = $service_details[2] : $data['shipping_code_inpostoc3_parcel_template_identifier'] = '';           
+            if ( !empty($data['shipping_code_inpostoc3_service_id']) && !empty($data['shipping_code_inpostoc3_parcel_template_identifier']) ) {
+                $filter['service_id'] = $data['shipping_code_inpostoc3_service_id'];
+                $filter['template_identifier'] = $data['shipping_code_inpostoc3_parcel_template_identifier'];
+                $pt = $this->model_extension_shipping_inpostoc3->getParcelTemplates($filter); // for this $filter setup there must be only one
+                $data['shipping_code_inpostoc3_parcel_template_id'] = $pt[0]['id'];
+            }
+             
             $data['shipping_code_inpostoc3_target_point'] = $shipping_code_details[2];
             $data['shipping_inpostoc3_geo_zone_use_api'][$data['shipping_code_inpostoc3_geo_zone_id']] = $this->config->get('shipping_inpostoc3_' . $data['shipping_code_inpostoc3_geo_zone_id'] . '_use_api');
             

--- a/upload/admin/controller/extension/shipping/inpostoc3.php
+++ b/upload/admin/controller/extension/shipping/inpostoc3.php
@@ -552,6 +552,9 @@ class ControllerExtensionShippingInPostOC3 extends Controller {
                     empty($data['shipments'][$o_shipment['id']]['sender']) ? $data['shipments'][$o_shipment['id']]['sender'] = $data['sender'] : '';
                 }
 
+                $data['senders'] = $this->model_extension_shipping_inpostoc3->getUniqueSenders();
+                $data['parcel_templates'] = $this->model_extension_shipping_inpostoc3->getParcelTemplates();
+
                 
                 /*foreach( $data['inpostoc3_services'] as $service ) {
                     if ( isset($this->request->post['inpostoc3_service_id_'.$service['service_identifier']]) ) {
@@ -733,7 +736,7 @@ class ControllerExtensionShippingInPostOC3 extends Controller {
     }
 
     // for AJAX calls and dynamic dropdown filling
-    // expecting ?route=extension/shipping/inpostoc3/sendingmethods&service_id=1&user_token=...
+    // sendingMethods: expecting ?route=extension/shipping/inpostoc3/sendingmethods&service_id=1&user_token=...
     public function sendingMethods() {
         $json = array();
 
@@ -744,11 +747,11 @@ class ControllerExtensionShippingInPostOC3 extends Controller {
             $this->load->language('extension/shipping/inpostoc3');
             $filter['id'] = $this->request->get['service_id'];
             $inpost_services = $this->model_extension_shipping_inpostoc3->getServicesWithAssocAttributes($filter);
-            $this->log->write(__METHOD__ . ' service: ' . print_r($inpost_services, true));
+            //$this->log->write(__METHOD__ . ' service: ' . print_r($inpost_services, true));
             
             foreach ( $inpost_services as $service ) {
 
-                $this->log->write(__METHOD__ . ' !empty: ' . print_r(!empty($service['sending_methods']), true));
+                //$this->log->write(__METHOD__ . ' !empty: ' . print_r(!empty($service['sending_methods']), true));
             
                 if ( !empty($service['sending_methods']) ) {
                     
@@ -757,9 +760,27 @@ class ControllerExtensionShippingInPostOC3 extends Controller {
                     }
                     
                     $json[$service['id']] = $service['sending_methods'];
-                    $this->log->write(__METHOD__ . ' json: ' . print_r($json, true));  
+                    //$this->log->write(__METHOD__ . ' json: ' . print_r($json, true));  
                 }
             }
+        }
+        $this->response->addHeader('Content-Type: application/json');
+        $this->response->setOutput(json_encode($json));
+    }
+
+    // senders: expecting ?route=extension/shipping/inpostoc3/senders&sender_id=1&user_token=...
+    public function senders() {
+        $json = array();
+        if ( !isset($this->request->get['sender_id']) ) {
+            $json['error']['warning'] = $this->language->get('error_no_sender');
+        } else {
+            $this->load->model('extension/shipping/inpostoc3');
+            $filter['s.sender_id'] = $this->request->get['sender_id'];
+            $senders = $this->model_extension_shipping_inpostoc3->getUniqueSenders($filter);
+            if (!empty($senders)) {
+               $json['sender_id']=$senders;
+            }
+            $this->log->write(__METHOD__ . ' json: ' . print_r($json, true)); 
         }
         $this->response->addHeader('Content-Type: application/json');
         $this->response->setOutput(json_encode($json));

--- a/upload/admin/controller/extension/shipping/inpostoc3.php
+++ b/upload/admin/controller/extension/shipping/inpostoc3.php
@@ -308,6 +308,8 @@ class ControllerExtensionShippingInPostOC3 extends Controller {
     
     // handle single order shipping
     public function orderShipping() {
+        $this->log->write(__METHOD__ ;
+
         $this->load->language('extension/shipping/inpostoc3');
         $this->document->setTitle($this->language->get('heading_title_order_shipping'));
              
@@ -363,7 +365,8 @@ class ControllerExtensionShippingInPostOC3 extends Controller {
         // expose variable for template
         $data['inpost_services'] =  $inpost_services;  
         
-        $data["inpostoc3_can_edit_shipment"] = true;
+        $data["inpostoc3_can_edit"]["shipment"] = true;
+        $data["inpostoc3_can_edit"]["sending_method_details"] = true;
         // TODO: check later if it is not present or in draft status
 
         if( isset($this->request->get['order_id']) ) {
@@ -376,6 +379,22 @@ class ControllerExtensionShippingInPostOC3 extends Controller {
                 // $data gets filled in with service & crucial settings details
                 $shipping_code_details = explode('.',$shipping_code);
                 $this->fillDataWithDetailsFromShippingCodeDetails($shipping_code_details, $data);
+
+                $filter['order_id'] = $data['order_id'];
+                $data['shipments'] = $this->model_extension_shipping_inpostoc3->getShipments($filter);
+                $this->log->write('Got shipments: ' . print_r($data['shipments'],true));
+                if (!empty( $data['shipments']) ) {
+                    // means no draft stuff was even created, need to save one before serving the view
+                    /*$init_shipment['status'] = 'draft';
+                    $init_shipment['order_id'] = $data['order_id'];
+                    $init_shipment['service_id'] = $data['shipping_code_inpostoc3_service_id'];
+                    // add receiver_id from order data
+                    $init_shipment['parcels'][0]['']
+                    $this->log->write('Set initial shipment: ' . print_r($data['shipments'],true));
+                    */
+                }
+                
+                
 
                 
                 /*foreach( $data['inpostoc3_services'] as $service ) {

--- a/upload/admin/controller/extension/shipping/inpostoc3.php
+++ b/upload/admin/controller/extension/shipping/inpostoc3.php
@@ -517,7 +517,9 @@ class ControllerExtensionShippingInPostOC3 extends Controller {
                     if (count($find['result'] ) == 1) {
                         $data["sender"]["country_iso_code_2"] = $find['result'][0]['sender_country_iso_code_2'];
                         $data["sender"]["country_iso_code_3"] = $find['result'][0]['sender_country_iso_code_3'];
-                    }  
+                    } 
+                    
+                    
                 }
 
                 $filter['order_id'] = $data['order_id'];
@@ -550,6 +552,20 @@ class ControllerExtensionShippingInPostOC3 extends Controller {
                     }
                     empty($data['shipments'][$o_shipment['id']]['receiver']) ? $data['shipments'][$o_shipment['id']]['receiver'] = $data['receiver'] : '';
                     empty($data['shipments'][$o_shipment['id']]['sender']) ? $data['shipments'][$o_shipment['id']]['sender'] = $data['sender'] : '';
+
+                    $cfilter['iso_code_2'] = $o_shipment["sender"]["country_iso_code_2"];
+                    $cfilter['iso_code_3'] = $o_shipment["sender"]["country_iso_code_3"];
+                    $sender_countries = $this->model_extension_shipping_inpostoc3->getCountriesByFilter($cfilter); //there ought to be one
+                    if ( count($sender_countries) == 1 ) {
+                        $data['sender_country_postcode_required'] = $sender_countries[0]["postcode_required"];
+                    }
+
+                    $cfilter['iso_code_2'] = $o_shipment["receiver"]["country_iso_code_2"];
+                    $cfilter['iso_code_3'] = $o_shipment["receiver"]["country_iso_code_3"];
+                    $receiver_countries = $this->model_extension_shipping_inpostoc3->getCountriesByFilter($cfilter); //there ought to be one
+                    if ( count($receiver_countries) == 1 ) {
+                        $data['receiver_country_postcode_required'] = $receiver_countries[0]["postcode_required"];
+                    }
                 }
 
                 $data['senders'] = $this->model_extension_shipping_inpostoc3->getUniqueSenders();
@@ -735,7 +751,7 @@ class ControllerExtensionShippingInPostOC3 extends Controller {
         return !$this->error;
     }
 
-    // for AJAX calls and dynamic dropdown filling
+    // ==== for AJAX calls and dynamic dropdown filling ====
     // sendingMethods: expecting ?route=extension/shipping/inpostoc3/sendingmethods&service_id=1&user_token=...
     public function sendingMethodsForService() {
         $json = array();
@@ -780,7 +796,7 @@ class ControllerExtensionShippingInPostOC3 extends Controller {
 
             $filter['id'] = $this->request->get['sending_method_id'];
             $sending_methods = $this->model_extension_shipping_inpostoc3->getSendingMethods($filter);
-            $sending_method = $sending_methods[0]; // dereference from multi-row structure
+            $sending_method = $sending_methods[0]; // dereference from multi-row structure, ought to be just one but if multiple entries present, as a rule of thumb, pick first one
             if ( !empty($sending_method) ) {
                 $sending_method['description'] = $this->language->get('text_sending_method_' . $sending_method['sending_method_identifier'] );
                 $json['sending_method'] = $sending_method;

--- a/upload/admin/controller/extension/shipping/inpostoc3.php
+++ b/upload/admin/controller/extension/shipping/inpostoc3.php
@@ -1041,6 +1041,5 @@ class ControllerExtensionShippingInPostOC3 extends Controller {
 		}
 		return (substr( $haystack, 0, strlen($needle) ) == $needle);
 	}
-
     
 }

--- a/upload/admin/controller/extension/shipping/inpostoc3.php
+++ b/upload/admin/controller/extension/shipping/inpostoc3.php
@@ -1196,6 +1196,9 @@ class ControllerExtensionShippingInPostOC3 extends Controller {
                         }
                         $data['orders'][$shipment['order_id']]['order_id'] = $shipment['order_id'];
                         $data['orders'][$shipment['order_id']]['labels'][$shipment['number']]['get_label_url'] = $this->url->link('extension/shipping/inpostoc3/ship2inpostapi', 'user_token=' . $this->session->data['user_token'] . '&inpostoc3_shipment_id=' .$shipment['id'] . '&geo_zone_id=' .$order['geo_zone_id'], true);
+                    }
+                }
+            }    
             //$this->log->write(__METHOD__ .' there\'s a POST received!');
         }
         if ( isset($this->request->get['inpostoc3_shipment_id']) && isset($this->request->get['geo_zone_id']) ) {

--- a/upload/admin/language/en-gb/extension/shipping/inpostoc3.php
+++ b/upload/admin/language/en-gb/extension/shipping/inpostoc3.php
@@ -29,6 +29,7 @@ $_['text_selected_sending_point']                   = 'Selected sending point';
 $_['text_selected_sending_address']                 = 'Selected sending address';
 $_['text_service']                                  = 'Service';
 $_['text_service_identifier']                       = 'Service identifier';
+$_['text_sending_method']                           = 'Sending method'; // 'Sposób nadania'
 $_['text_sending_method_parcel_locker']             = 'I will post a package at parcel locker'; // 'Nadam przesyłkę w Paczkomacie'
 $_['text_shipments']                                = 'Shipments';
 $_['text_send_from']                                = 'Send from'; // 'Nadanie z'
@@ -72,3 +73,4 @@ $_['button_shipping_print']                         = 'Get Label from InPost. On
 // Error
 $_['error_permission']                              = 'Warning: You do not have permission to modify InPosst OC3 shipping!';
 $_['error_insufficient_shipment_data']              = 'Insufficient shipment data!';
+$_['error_no_service']                              = 'No service id!';

--- a/upload/admin/language/en-gb/extension/shipping/inpostoc3.php
+++ b/upload/admin/language/en-gb/extension/shipping/inpostoc3.php
@@ -25,7 +25,7 @@ $_['text_template_description_size_medium']         = 'Parcel template size: med
 $_['text_template_description_size_large']          = 'Parcel template size: large'; // Gabaryt C  
 $_['text_selected_target_point']                    = 'Selected target point';
 $_['text_selected_sending_method']                  = 'Selected sending method';
-$_['text_selected_sending_point']                   = 'Selected sending point';
+$_['text_selected_sending_point']                   = 'Selected dropoff point';
 $_['text_selected_sending_address']                 = 'Selected sending address';
 $_['text_service']                                  = 'Service';
 $_['text_service_identifier']                       = 'Service identifier';
@@ -39,7 +39,21 @@ $_['text_shipment_number']                          = 'Shipment number';
 $_['text_shipment_tracking_number']                 = 'Shipment tracking number';
 $_['text_parcel_number']                            = 'Parcel number';
 $_['text_parcel_tracking_number']                   = 'Parcel tracking number';
-
+$_['text_name']                                     = 'Name';
+$_['text_company_name']                             = 'Company name';
+$_['text_first_name']                               = 'First name';
+$_['text_last_name']                                = 'Last name';
+$_['text_email']                                    = 'Email';
+$_['text_phone']                                    = 'Phone';
+$_['text_addr_street']                              = 'Street';
+$_['text_addr_building_number']                     = 'Building number';
+$_['text_addr_line_1']                              = 'Address line 1';
+$_['text_addr_line_2']                              = 'Address line 2';
+$_['text_addr_city']                                = 'City';
+$_['text_addr_post_code']                           = 'Post code';
+$_['text_addr_country_code']                        = 'Country';
+$_['text_addr_new']                                 = '-- Select or enter details';
+$_['text_click_to_select']                          = 'Click to select...';
 
 // Entry
 $_['entry_status']                                  = 'Status';
@@ -58,6 +72,7 @@ $_['entry_api_endpoint']                            = 'API address';
 $_['entry_api_token']                               = 'API Token';
 $_['entry_api_org_id']                              = 'API organization id';
 $_['entry_sending_method_parcel_locker']            = 'Post at parcel locker';  // 'Nadanie w Paczkomacie'
+$_['entry_sendfrom']                                = 'Sending from country';
 
 // Help
 $_['help_rate']                                     = 'Example: small:10.00,medium:12.00 Parcel template size:Cost,Parcel template size:Cost, etc...';

--- a/upload/admin/language/en-gb/extension/shipping/inpostoc3.php
+++ b/upload/admin/language/en-gb/extension/shipping/inpostoc3.php
@@ -52,7 +52,7 @@ $_['text_addr_line_2']                              = 'Address line 2';
 $_['text_addr_city']                                = 'City';
 $_['text_addr_post_code']                           = 'Post code';
 $_['text_addr_country_code']                        = 'Country';
-$_['text_addr_new']                                 = '-- Select or enter details';
+$_['text_addr_new']                                 = '-- Enter new sender details';
 $_['text_click_to_select']                          = 'Click to select...';
 
 // Entry
@@ -73,6 +73,7 @@ $_['entry_api_token']                               = 'API Token';
 $_['entry_api_org_id']                              = 'API organization id';
 $_['entry_sending_method_parcel_locker']            = 'Post at parcel locker';  // 'Nadanie w Paczkomacie'
 $_['entry_sendfrom']                                = 'Sending from country';
+$_['entry_name']                                    = '* Enter \'Name\' in the form';
 
 // Help
 $_['help_rate']                                     = 'Example: small:10.00,medium:12.00 Parcel template size:Cost,Parcel template size:Cost, etc...';
@@ -89,3 +90,4 @@ $_['button_shipping_print']                         = 'Get Label from InPost. On
 $_['error_permission']                              = 'Warning: You do not have permission to modify InPosst OC3 shipping!';
 $_['error_insufficient_shipment_data']              = 'Insufficient shipment data!';
 $_['error_no_service']                              = 'No service id!';
+$_['error_no_sender']                               = 'No sender id!';

--- a/upload/admin/language/en-gb/extension/shipping/inpostoc3.php
+++ b/upload/admin/language/en-gb/extension/shipping/inpostoc3.php
@@ -90,4 +90,5 @@ $_['button_shipping_print']                         = 'Get Label from InPost. On
 $_['error_permission']                              = 'Warning: You do not have permission to modify InPosst OC3 shipping!';
 $_['error_insufficient_shipment_data']              = 'Insufficient shipment data!';
 $_['error_no_service']                              = 'No service id!';
+$_['error_no_sending_method']                       = 'No sending method id!';
 $_['error_no_sender']                               = 'No sender id!';

--- a/upload/admin/language/en-gb/extension/shipping/inpostoc3.php
+++ b/upload/admin/language/en-gb/extension/shipping/inpostoc3.php
@@ -85,7 +85,7 @@ $_['help_parcel_template_length_class']             = 'Length class for InPost p
 $_['help_sendfrom']                                 = 'Select ISO alpha 3 code for country, from which shipments are sent to receivers in this Geo Zone';
 
 // Button
-$_['button_shipping_print']                         = 'Get Label from InPost. Once done, shipment cannot be edited.';
+$_['button_shipping_print']                         = 'Get Label from InPost. Once done, shipment cannot be edited. If shipment in edit state, saves current shipment prior to getting a label.';
 $_['button_shipping_save']                          = 'Save draft. Shipment can be edited later.';
 
 // Error
@@ -94,3 +94,5 @@ $_['error_insufficient_shipment_data']              = 'Insufficient shipment dat
 $_['error_no_service']                              = 'No service id!';
 $_['error_no_sending_method']                       = 'No sending method id!';
 $_['error_no_sender']                               = 'No sender id!';
+$_['error_curl_not_installed']                      = 'cURL is not installed on this server!';
+$_['error_shipment_already_created]']               = 'Sorry, not saved! Shipment was already saved and sent via API by someone else!';

--- a/upload/admin/language/en-gb/extension/shipping/inpostoc3.php
+++ b/upload/admin/language/en-gb/extension/shipping/inpostoc3.php
@@ -27,6 +27,7 @@ $_['text_selected_target_point']                    = 'Selected target point';
 $_['text_selected_sending_method']                  = 'Selected sending method';
 $_['text_selected_sending_point']                   = 'Selected sending point';
 $_['text_selected_sending_address']                 = 'Selected sending address';
+$_['text_service']                                  = 'Service';
 $_['text_service_identifier']                       = 'Service identifier';
 $_['text_sending_method_parcel_locker']             = 'I will post a package at parcel locker'; // 'Nadam przesyłkę w Paczkomacie'
 $_['text_shipments']                                = 'Shipments';
@@ -37,6 +38,7 @@ $_['text_shipment_number']                          = 'Shipment number';
 $_['text_shipment_tracking_number']                 = 'Shipment tracking number';
 $_['text_parcel_number']                            = 'Parcel number';
 $_['text_parcel_tracking_number']                   = 'Parcel tracking number';
+
 
 // Entry
 $_['entry_status']                                  = 'Status';

--- a/upload/admin/language/en-gb/extension/shipping/inpostoc3.php
+++ b/upload/admin/language/en-gb/extension/shipping/inpostoc3.php
@@ -54,6 +54,7 @@ $_['text_addr_post_code']                           = 'Post code';
 $_['text_addr_country_code']                        = 'Country';
 $_['text_addr_new']                                 = '-- Enter new sender details';
 $_['text_click_to_select']                          = 'Click to select...';
+$_['text_order']                                    = 'Order';
 
 // Entry
 $_['entry_status']                                  = 'Status';

--- a/upload/admin/language/en-gb/extension/shipping/inpostoc3.php
+++ b/upload/admin/language/en-gb/extension/shipping/inpostoc3.php
@@ -55,6 +55,7 @@ $_['text_addr_country_code']                        = 'Country';
 $_['text_addr_new']                                 = '-- Enter new sender details';
 $_['text_click_to_select']                          = 'Click to select...';
 $_['text_order']                                    = 'Order';
+$_['text_shipment_saved']                           = 'Shipment saved!';
 
 // Entry
 $_['entry_status']                                  = 'Status';

--- a/upload/admin/language/en-gb/extension/shipping/inpostoc3.php
+++ b/upload/admin/language/en-gb/extension/shipping/inpostoc3.php
@@ -84,7 +84,8 @@ $_['help_parcel_template_length_class']             = 'Length class for InPost p
 $_['help_sendfrom']                                 = 'Select ISO alpha 3 code for country, from which shipments are sent to receivers in this Geo Zone';
 
 // Button
-$_['button_shipping_print']                         = 'Get Label from InPost. Once done, Shipment cannot be edited.';
+$_['button_shipping_print']                         = 'Get Label from InPost. Once done, shipment cannot be edited.';
+$_['button_shipping_save']                          = 'Save draft. Shipment can be edited later.';
 
 // Error
 $_['error_permission']                              = 'Warning: You do not have permission to modify InPosst OC3 shipping!';

--- a/upload/admin/language/en-gb/extension/shipping/inpostoc3.php
+++ b/upload/admin/language/en-gb/extension/shipping/inpostoc3.php
@@ -67,7 +67,8 @@ $_['help_parcel_template_length_class']             = 'Length class for InPost p
 $_['help_sendfrom']                                 = 'Select ISO alpha 3 code for country, from which shipments are sent to receivers in this Geo Zone';
 
 // Button
-$_['button_shipping_print']                          = 'Get Label from InPost. Once done, Shipment cannot be edited.';
+$_['button_shipping_print']                         = 'Get Label from InPost. Once done, Shipment cannot be edited.';
 
 // Error
-$_['error_permission'] = 'Warning: You do not have permission to modify InPosst OC3 shipping!';
+$_['error_permission']                              = 'Warning: You do not have permission to modify InPosst OC3 shipping!';
+$_['error_insufficient_shipment_data']              = 'Insufficient shipment data!';

--- a/upload/admin/model/extension/shipping/inpostoc3.php
+++ b/upload/admin/model/extension/shipping/inpostoc3.php
@@ -439,11 +439,11 @@ class ModelExtensionShippingInPostOC3 extends Model {
         $allowed_keys = array ("id", "order_id", "number", "tracking_number", "receiver_id", "sender_id", "service_id", "is_return");
 
         $sql = $sql . $this->sqlBuildSimpleWhere($filter, $allowed_keys) . ";";
-        $this->log->write(__METHOD__ . ' $sql: ' .$sql);
+        //$this->log->write(__METHOD__ . ' $sql: ' .$sql);
 
         $query = $this->db->query ($sql);
 
-        $this->log->write(__METHOD__ . ' $query: ' . print_r($query,true));
+        //$this->log->write(__METHOD__ . ' $query: ' . print_r($query,true));
         $result = array();
         foreach($query->rows as $row){
             
@@ -466,7 +466,7 @@ class ModelExtensionShippingInPostOC3 extends Model {
 
             $result[$row['id']]=$row;
             
-            $this->log->write(__METHOD__ . ' $row: ' . print_r($row,true));
+            //$this->log->write(__METHOD__ . ' $row: ' . print_r($row,true));
 
         }
         return $result;
@@ -557,7 +557,7 @@ class ModelExtensionShippingInPostOC3 extends Model {
         $sql = $this->sqlBuildSimplePartsForInsertOnDupKey(array_intersect_key($addr, $allowed_keys),$target);
         $this->db->query($sql);
         $addr_id = $this->db->getLastId();
-        $this->log->write(__METHOD__ . '$addr_id: ' . print_r($addr_id,true));
+        // $this->log->write(__METHOD__ . '$addr_id: ' . print_r($addr_id,true));
         // mysql last_insert_id may return 0, if e.g. only one of 2 addresses was updated and the other not at all in two subsequent, very closely done queries.
         // therefore, to avoid breaking relationships, use it only for newly inserted rows.
         return ( isset($addr['id']) ? $addr['id'] : $addr_id );
@@ -632,12 +632,10 @@ class ModelExtensionShippingInPostOC3 extends Model {
         );
 
         // oc3 uses MyISAM engine - no universal support for transaction for multiple queries, so one by one...
-        $this->log->write(__METHOD__ . '$shipment: ' . print_r($shipment,true));
         if ( !empty($shipment['receiver']) ) {
             $shipment['receiver_id'] = $this->saveAddress($shipment['receiver']);
         }
-        $this->log->write(__METHOD__ . '$shipment[receiver_id] po zapisie: ' . print_r($shipment['receiver_id'],true));
-        $this->log->write(__METHOD__ . '$shipment[receiver] po zapisie: ' . print_r($shipment['receiver'],true));
+
         if ( !empty($shipment['sender']) ) {
             $shipment['sender_id'] = $this->saveAddress($shipment['sender']);
         }
@@ -671,7 +669,7 @@ class ModelExtensionShippingInPostOC3 extends Model {
     // requires $input array as flat key => val assoc array containing keys as columns for $target['table_name']
     protected function sqlBuildSimplePartsForInsertOnDupKey( $inputArr, $target ) {
         $sql = '';
-        $this->log->write(__METHOD__ . '$inputAtr: ' . print_r($inputArr,true));
+        //$this->log->write(__METHOD__ . '$inputAtr: ' . print_r($inputArr,true));
         $columns = "`".implode("`,`",array_keys($inputArr))."`";
         //instead of array_map('mysqli_real_escape_string', array_values($inputArr)); uses $this->db->escape for conformity with OC3 framework
         foreach($inputArr as $i => $val) {
@@ -698,7 +696,7 @@ class ModelExtensionShippingInPostOC3 extends Model {
             " . implode(",", $finalArr). ";
         ";
 
-         $this->log->write(__METHOD__ . '$sql: ' . print_r($sql,true));
+        // $this->log->write(__METHOD__ . '$sql: ' . print_r($sql,true));
         return $sql;
     }
 

--- a/upload/admin/model/extension/shipping/inpostoc3.php
+++ b/upload/admin/model/extension/shipping/inpostoc3.php
@@ -166,21 +166,26 @@ class ModelExtensionShippingInPostOC3 extends Model {
 
     }
     
-    public function uninstall() {
+    public function uninstall($service_id=null) {
         //$this->log->write(print_r('model\extension\shipping\inpostoc3 uninstall before db uninstall', true));
         // do nothing, preserve data 
     }
 
-    public function getServices() {
+    public function getServices($filter = array()) {
         
-        $query = $this->db->query("
-            SELECT * FROM `inpostoc3_services`;
-        ");
-        $results = array();
+        $result = null;
+        $sql = "
+            SELECT * FROM `inpostoc3_services` 
+        ";
+        $allowed_keys = array ("id", "service_identifier");
+
+        $sql = $sql . $this->sqlBuildSimpleWhere($filter, $allowed_keys) . ";";
+        $query = $this->db->query($sql);
+        $result = array();
         foreach($query->rows as $row){
-            $results[]=$row;
+            $result[]=$row;
         }
-        return $results; 
+        return $result; 
     }
 
     public function getParcelTemplates( $filter = array() ) {
@@ -294,8 +299,8 @@ class ModelExtensionShippingInPostOC3 extends Model {
         return $result; 
     }
 
-    public function getServicesWithAssocAttributes() {
-        $services = $this->getServices();
+    public function getServicesWithAssocAttributes($filter=array()) {
+        $services = $this->getServices($filter);
         $parcel_templates = $this->getParcelTemplates();
         $services_sending_methods = $this->getServicesToSendingMethods();
         $services_allowed_routes = $this->getServicesAllowedRoutes();
@@ -346,7 +351,7 @@ class ModelExtensionShippingInPostOC3 extends Model {
         $sql = "
         SELECT * FROM `inpostoc3_custom_attributes`
         ";
-        $allowed_keys = array ("id", "shipment_id", "target_point", "dropoff_point","dispatch_order_id","allegro_user_id","allegro_transaction_id");
+        $allowed_keys = array ("id", "shipment_id", "target_point", "dropoff_point","sending_method","dispatch_order_id","allegro_user_id","allegro_transaction_id");
 
         $sql = $sql . $this->sqlBuildSimpleWhere($filter, $allowed_keys) . ";";
 
@@ -370,7 +375,7 @@ class ModelExtensionShippingInPostOC3 extends Model {
 
         $query = $this->db->query ($sql);
 
-        $this->log->write(__METHOD__ . ' $query: ' . print_r($query,true));
+        //$this->log->write(__METHOD__ . ' $query: ' . print_r($query,true));
         $result = array();
         foreach($query->rows as $row){
             
@@ -379,7 +384,7 @@ class ModelExtensionShippingInPostOC3 extends Model {
             $row['custom_attributes'] = $this->getCustomAttributes($filter2)[0]; // one set per shipment
             $result[$row['id']]=$row;
 
-            $this->log->write(__METHOD__ . ' $row: ' . print_r($row,true));
+            //$this->log->write(__METHOD__ . ' $row: ' . print_r($row,true));
 
         }
         return $result;

--- a/upload/admin/model/extension/shipping/inpostoc3.php
+++ b/upload/admin/model/extension/shipping/inpostoc3.php
@@ -482,7 +482,7 @@ class ModelExtensionShippingInPostOC3 extends Model {
         $result = array();
         foreach($query->rows as $row){
 
-            $this->log->write(__METHOD__ . ' $row before: ' . print_r($row,true));
+            //$this->log->write(__METHOD__ . ' $row before: ' . print_r($row,true));
             
             $filter2['shipment_id'] = $row['id'];
             $row['parcels'] = $this->getParcels($filter2);
@@ -503,7 +503,7 @@ class ModelExtensionShippingInPostOC3 extends Model {
 
             $result[$row['id']]=$row;
             
-            $this->log->write(__METHOD__ . ' $row after: ' . print_r($row,true));
+            //$this->log->write(__METHOD__ . ' $row after: ' . print_r($row,true));
 
         }
         return $result;
@@ -616,7 +616,7 @@ class ModelExtensionShippingInPostOC3 extends Model {
             'is_non_standard' => null
         );
 
-        $sql = $sql = $this->sqlBuildSimplePartsForInsertOnDupKey(array_intersect_key($parcel, $allowed_keys),$target);
+        $sql = $this->sqlBuildSimplePartsForInsertOnDupKey(array_intersect_key($parcel, $allowed_keys),$target);
 
         $this->db->query($sql);
         $parcel_id = $this->db->getLastId();

--- a/upload/admin/model/extension/shipping/inpostoc3.php
+++ b/upload/admin/model/extension/shipping/inpostoc3.php
@@ -1,6 +1,25 @@
 <?php
 
 class ModelExtensionShippingInPostOC3 extends Model {
+    const NONE = 0;
+    const SENDING_METHODS = array(
+        "parcel_locker" => array (
+            "id" => 1,
+            "sending_method_identifier" => "parcel_locker"
+        )
+    );
+    const SHIPMENT_STATUS_DRAFT = 'draft'; 
+
+    public function getSHIPMENT_STATUS_DRAFT() {
+        return self::SHIPMENT_STATUS_DRAFT;
+    }
+
+    public function getNONE() {
+        return self::NONE;
+    }
+    public function getSENDING_METHODS() {
+        return self::SENDING_METHODS;
+    }
     
     public function install() {
         //$this->log->write(print_r('model\extension\shipping\inpostoc3 install before db install', true));
@@ -16,11 +35,15 @@ class ModelExtensionShippingInPostOC3 extends Model {
                 PRIMARY KEY(`id`)
           ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
         ");
-
-        $this->db->query("       
-            INSERT IGNORE INTO `inpostoc3_services` (`id`,`service_identifier`) VALUES
-            ( 1 , 'inpost_locker_standard' );
-        ");
+        $sql="
+            INSERT IGNORE INTO `inpostoc3_sending_method` (`id`,`sending_method_identifier`) VALUES
+        ";
+        foreach(self::SENDING_METHODS as $sending_method) {
+            $sql .= "(". $sending_method['id'] .", '". $sending_method['sending_method_identifier']. "'),";
+        }
+        $sql = substr($sql, 0, -1);
+        $sql .= ";" ;
+        $this->db->query($sql);
 
         $this->db->query("
             CREATE TABLE IF NOT EXISTS `inpostoc3_services_routing` (

--- a/upload/admin/model/extension/shipping/inpostoc3.php
+++ b/upload/admin/model/extension/shipping/inpostoc3.php
@@ -375,6 +375,54 @@ class ModelExtensionShippingInPostOC3 extends Model {
         return $result;
     }
 
+    public function createParcel($parcel) {
+
+        $sql = "
+            INSERT INTO `inpostoc3_parcels`
+            (`shipment_id`,`template_id`)
+            VALUES
+            ( 
+                '". $parcel['shipment_id'] .",
+                '". $parcel['template_id'] ."
+            );
+        ";
+        $this->db->query($sql);
+        $parcel_id = $this->db->getLastId();
+        return $parcel_id;
+    }
+
+    public function createCustomAttributes($cattr) {
+        $sql = "
+            INSERT INTO `inpostoc3_custom_attributes` 
+            (`shipment_id`,`target_point`)
+            VALUES
+            (
+                '". $cattr['id']."',
+                '". $cattr['shipment_id']."'
+            );
+        ";
+        $this->db->query($sql);
+        $cattr_id = $this->db->getLastId();
+        return $cattr_id;
+    }
+
+    public function createShipment($shipment) {
+        
+        $sql ="
+            INSERT INTO `inpostoc3_shipments` 
+            (`order_id`,`service_id`,`status`)
+            VALUES 
+            (
+                '". $shipment['order_id']."',
+                '". $shipment['service_id']."',
+                '". $shipment['status']."'
+            );
+        ";
+        $this->db->query($sql);
+        $shipment_id = $this->db->getLastId();
+        return $shipment_id;
+    }
+
     public function saveParcel($parcel) {
 
         /*$defaultParcel = array(

--- a/upload/admin/model/extension/shipping/inpostoc3.php
+++ b/upload/admin/model/extension/shipping/inpostoc3.php
@@ -106,6 +106,31 @@ class ModelExtensionShippingInPostOC3 extends Model {
         ");
         
         $this->db->query("
+            CREATE TABLE IF NOT EXISTS `inpostoc3_address` (
+                `id` INT(11) UNIQUE AUTO_INCREMENT,
+                `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                `updated_at` TIMESTAMP NULL ON UPDATE CURRENT_TIMESTAMP,
+                `name` varchar(100) NULL,
+                `company_name` varchar(100) NULL,
+                `first_name` varchar(100) NULL,
+                `last_name` varchar(100) NULL,  
+                `phone` varchar(100) NULL,
+                `email` varchar(300) NULL,
+                `street` varchar(300) NULL,
+                `building_number` varchar(100) NULL,
+                `line1` varchar(300) NULL,
+                `line2` varchar(300) NULL,
+                `city` varchar(300) NULL,
+                `post_code` varchar(100) NULL,
+                `country_iso_code_2` CHAR(3) NULL COMMENT 'ISO 3166-1 alfa-2 code',
+                `country_iso_code_3` CHAR(3) NULL COMMENT 'ISO 3166-1 alfa-3 code',
+                `sender` tinyint(1) DEFAULT 0,
+                `receiver` tinyint(1) DEFAULT 0,
+                PRIMARY KEY(`id`)
+            ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
+        ");
+        
+        $this->db->query("
             CREATE TABLE IF NOT EXISTS `inpostoc3_shipments` (
                 `id` INT(11) UNIQUE AUTO_INCREMENT,
                 `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -115,13 +140,16 @@ class ModelExtensionShippingInPostOC3 extends Model {
                 `number` varchar(100) NULL,
                 `tracking_number` varchar(100) NULL,  
                 `status` varchar(100) NULL,
-                `receiver_id` varchar(100) NULL,
+                `receiver_id` INT(11) NULL,
+                `sender_id` INT(11) NULL,
                 `additional_services` tinyint(1) DEFAULT 0,
                 `is_return` tinyint(1) DEFAULT 0,
                 PRIMARY KEY(`id`),
                 INDEX (`order_id`),
                 FOREIGN KEY (`order_id`) REFERENCES `" . DB_PREFIX . "oc_order`(`id`),
-                FOREIGN KEY (`service_id`) REFERENCES `inpostoc3_services`(`id`)
+                FOREIGN KEY (`service_id`) REFERENCES `inpostoc3_services`(`id`),
+                FOREIGN KEY (`sender_id`) REFERENCES `inpostoc3_address`(`id`),
+                FOREIGN KEY (`receiver_id`) REFERENCES `inpostoc3_address`(`id`)
             ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
         ");
 
@@ -382,6 +410,8 @@ class ModelExtensionShippingInPostOC3 extends Model {
             $filter2['shipment_id'] = $row['id'];
             $row['parcels'] = $this->getParcels($filter2);
             $row['custom_attributes'] = $this->getCustomAttributes($filter2)[0]; // one set per shipment
+            $filter3['id'] = $row['service_id'];
+            $row['service_identifier'] = $this->getServices($filter3)[0]['service_identifier']; //one set per shipment
             $result[$row['id']]=$row;
 
             //$this->log->write(__METHOD__ . ' $row: ' . print_r($row,true));

--- a/upload/admin/model/extension/shipping/inpostoc3.php
+++ b/upload/admin/model/extension/shipping/inpostoc3.php
@@ -392,6 +392,12 @@ class ModelExtensionShippingInPostOC3 extends Model {
         $query = $this->db->query ($sql);
         $result = array();
         foreach($query->rows as $row){
+            if ( !empty($row['template_id']) ) {
+                $filter['id'] = $row['template_id'];
+                $ptmplts = $this->getParcelTemplates($filter);
+                $pt = reset ($ptmplts); // get first one
+                $row['template_identifier'] = $pt['template_identifier'];
+            }
             $result[$row['id']]=$row;
         }
         return $result;
@@ -409,6 +415,12 @@ class ModelExtensionShippingInPostOC3 extends Model {
         $query = $this->db->query ($sql);
         $result = array();
         foreach($query->rows as $row){
+            if (!empty($row['sending_method']) ) {
+                $filter['id']=$row['sending_method'];
+                $smtds = $this->getSendingMethods($filter);
+                $sm = reset ($smtds); // one sending method
+                $row['sending_method_identifier'] = $sm['sending_method_identifier'];
+            }
             $result[]=$row;
         }
         return $result;
@@ -469,6 +481,8 @@ class ModelExtensionShippingInPostOC3 extends Model {
         //$this->log->write(__METHOD__ . ' $query: ' . print_r($query,true));
         $result = array();
         foreach($query->rows as $row){
+
+            $this->log->write(__METHOD__ . ' $row before: ' . print_r($row,true));
             
             $filter2['shipment_id'] = $row['id'];
             $row['parcels'] = $this->getParcels($filter2);
@@ -489,7 +503,7 @@ class ModelExtensionShippingInPostOC3 extends Model {
 
             $result[$row['id']]=$row;
             
-            //$this->log->write(__METHOD__ . ' $row: ' . print_r($row,true));
+            $this->log->write(__METHOD__ . ' $row after: ' . print_r($row,true));
 
         }
         return $result;

--- a/upload/admin/model/extension/shipping/inpostoc3.php
+++ b/upload/admin/model/extension/shipping/inpostoc3.php
@@ -756,7 +756,7 @@ class ModelExtensionShippingInPostOC3 extends Model {
         return $sql;
     }
 
-    public function getCountriesByFilter($filter) {
+    public function getCountriesByFilter($filter=array()) {
         $result = null;
         $sql = "
         SELECT * FROM `" . DB_PREFIX . "country`

--- a/upload/admin/model/extension/shipping/inpostoc3.php
+++ b/upload/admin/model/extension/shipping/inpostoc3.php
@@ -509,6 +509,25 @@ class ModelExtensionShippingInPostOC3 extends Model {
 
     }
 
+    function getSendingMethods($filter=array()) {
+        $result = null;
+        $sql = "
+        SELECT * FROM `inpostoc3_sending_method`
+        ";
+        $allowed_keys = array ("id", "sending_method_identifier");
+
+        $sql = $sql . $this->sqlBuildSimpleWhere($filter, $allowed_keys) . ";";
+        $this->log->write(__METHOD__ . ' $sql: ' .$sql);
+
+        $query = $this->db->query ($sql);
+        //$this->log->write(__METHOD__ . ' $query: ' . print_r($query,true));
+        $result = array();
+        foreach($query->rows as $row){           
+            $result[]=$row;
+        }
+        return $result;
+    }
+
     public function createParcel($parcel) {
 
         $sql = "

--- a/upload/admin/view/javascript/inpostoc3.js
+++ b/upload/admin/view/javascript/inpostoc3.js
@@ -35,6 +35,61 @@ $(document).ready(function() {
     });
   });
 
+  $('[id^="input-inpostoc3-select-sender-"]').on('change',function() {
+    //console.log('new: ' + $(this).attr('id') + '  val: ' + $(this).val());
+    if ( $(this).val() == 0 ) { return ;}
+    var items = $(this).attr('id').split('-');
+    //console.log('items: ' + items);
+    var elements = { 
+      "const" : "input-inpostoc3",
+      "order_id" : items[4],
+      "shipment_id" : items[5] 
+    };
+    var ending = items[5] + '-' + items[5];
+    //console.log('shipment: ' + shipment["id"]);
+    var sender_id = $(this).val();
+
+    $.ajax(
+      {
+        url: 'index.php?route=extension/shipping/inpostoc3/senders&sender_id=' + sender_id + '&user_token=' + getUserToken(),
+        type: 'get',
+        error: function(xhr, ajaxOptions, thrownError) {
+          alert(thrownError + "\r\n" + xhr.statusText + "\r\n" + xhr.responseText);
+        },
+        success: function(data, status) {
+          if ($.trim(data)){   
+            $.each( data, function( saId, saObj ) {
+              $.each (saObj, function(sId, sObj) {
+                console.log(' sender_id + company name: ' + sObj["id"] + '  ' + sObj["company_name"]); 
+                $("#input-inpostoc3-sender-name-"+ ending ).val(sObj["name"]);
+                $("#input-inpostoc3-sender-company-name-"+ ending ).val(sObj["company_name"]);
+                $("#input-inpostoc3-sender-first-name-"+ ending ).val(sObj["first_name"]);
+                $("#input-inpostoc3-sender-last-name-"+ ending ).val(sObj["last_name"]);
+                $("#input-inpostoc3-sender-email-"+ ending ).val(sObj["email"]);
+                $("#input-inpostoc3-sender-phone]-"+ ending ).val(sObj["phone"]);
+                $("#input-inpostoc3-sender-addr-street-"+ ending ).val(sObj["street"]);
+                $("#input-inpostoc3-sender-addr-building-number-"+ ending ).val(sObj["building_number"]);
+                $("#input-inpostoc3-sender-addr-line-1-"+ ending ).val(sObj["line1"]);
+                $("#input-inpostoc3-sender-addr-line-2-"+ ending ).val(sObj["line2"]);
+                $("#input-inpostoc3-sender-addr-city-"+ ending ).val(sObj["city"]);
+                $("#input-inpostoc3-sender-addr-post-code-"+ ending ).val(sObj["post_code"]);
+                $("#input-inpostoc3-sender-addr-country-code-"+ ending).val(sObj["country_iso_code_2"]);
+            });       
+            });
+          }
+        }
+      });
+    });
+    
+
+});
+
+$(document).on('change', '[id^="input-inpostoc3-sending-method-"]', function() {
+  if ( $(this).val() == 1 ) {
+    $('[id^="input-inpostoc3-sender-selected-point-"]').prop('disabled', false);
+  } else {
+    $('[id^="input-inpostoc3-sender-selected-point-"]').prop('disabled', true);
+  }
 });
 
 

--- a/upload/admin/view/javascript/inpostoc3.js
+++ b/upload/admin/view/javascript/inpostoc3.js
@@ -110,7 +110,7 @@ $(document).ready(function() {
                 $("#input-inpostoc3-sender-email-"+ ending ).val(sObj["email"]);
                 $("#input-inpostoc3-sender-phone]-"+ ending ).val(sObj["phone"]);
                 $("#input-inpostoc3-sender-addr-street-"+ ending ).val(sObj["street"]);
-                $("#input-inpostoc3-sender-addr-building-number-"+ ending ).val(sObj["building_number"]);
+                $("#input-inpostoc3-sender-addr-building_number-"+ ending ).val(sObj["building_number"]);
                 $("#input-inpostoc3-sender-addr-line-1-"+ ending ).val(sObj["line1"]);
                 $("#input-inpostoc3-sender-addr-line-2-"+ ending ).val(sObj["line2"]);
                 $("#input-inpostoc3-sender-addr-city-"+ ending ).val(sObj["city"]);
@@ -131,6 +131,58 @@ $(document).ready(function() {
       $("#input-inpostoc3-sender-selected-point-" + items[4] + '-' + items[5] ).prop('disabled', true);
     }
   });
+
+  // make either address lines or street & building not required - 2 functions
+  var $inputs_addr_line = $('[id*="-addr-line-1-"],[id*="-addr-line-2-"]');
+  $inputs_addr_line.on('input', function () {
+      // Set the required property of the other input to false if this input is not empty.
+      var items = $(this).attr('id').split('-');
+      var elid = {};
+      elid.beginning = items[0] + '-' + items[1] + '-' + items[2];
+      elid.end = items[6] + '-' + items[7];
+      if ( $('#' + elid.beginning + '-addr-building_number-' + elid.end).val().length > 0  
+          ||  $('#' + elid.beginning + '-addr-street-' + elid.end).val().length > 0
+      ) {
+        $('#' + elid.beginning + '-addr-building_number-' + elid.end).prop('required', true);
+        $('#' + elid.beginning + '-addr_building_number_row-' + elid.end).addClass("required");
+        $('#' + elid.beginning + '-addr-street-' + elid.end).prop('required', true);
+        $('#' + elid.beginning + '-addr_street_row-' + elid.end).addClass("required");
+      } else {
+        $('#' + elid.beginning + '-addr-building_number-' + elid.end).prop('required', !$(this).val().length);
+        $('#' + elid.beginning + '-addr_building_number_row-' + elid.end).removeClass("required");
+        $('#' + elid.beginning + '-addr-street-' + elid.end).prop('required', !$(this).val().length);
+        $('#' + elid.beginning + '-addr_street_row-' + elid.end).removeClass("required");
+        $(this).prop('required', true);
+        $('#'+ elid.beginning + '-' + items[3] + '_' + items[4] + '_' + items[5] + '_row-' + elid.end).addClass("required");
+      }
+  });
+
+  var $inputs_street_buildingno = $('[id*="-addr-building_number-"],[id*="-addr-street-"]');
+  $inputs_street_buildingno.on('input', function () {
+    var items = $(this).attr('id').split('-');
+    var elid = {};
+    elid.beginning = items[0] + '-' + items[1] + '-' + items[2];
+    elid.end = items[5] + '-' + items[6];
+    $('#' + elid.beginning + '-addr-line-1-' + elid.end).prop('required', !$(this).val().length);
+    $('#' + elid.beginning + '-addr_line_1_row-' + elid.end).removeClass("required");
+    $('#' + elid.beginning + '-addr-line-2-' + elid.end).prop('required', !$(this).val().length);
+    $('#' + elid.beginning + '-addr_line_2_row-' + elid.end).removeClass("required");
+    $('#'+ elid.beginning + '-addr_building_number-' + elid.end).prop('required', true);
+    $('#'+ elid.beginning + '-addr_building_number_row-' + elid.end).addClass("required");
+    $('#'+ elid.beginning + '-addr_street-' + elid.end).prop('required', true);
+    $('#'+ elid.beginning + '-addr_street_row-' + elid.end).addClass("required");
+  });
+
+  /*
+  var $required_inputs = $(":input[required]");
+  $required_inputs.on('input', function() {
+    var formid = $(this).attr('form');
+    console.log('#'+formid+' input[required]');
+    $('#'+formid+' input[required]').each( function(i) {
+     if ( $(this).val()=="" ) { console.log('o-o, empty' + $(this).attr('id') ); } 
+    });
+  });
+  */
 
 });
 

--- a/upload/admin/view/javascript/inpostoc3.js
+++ b/upload/admin/view/javascript/inpostoc3.js
@@ -51,8 +51,12 @@ $(document).ready(function() {
     // console.log("input-inpostoc3-receiver-selected-point-" + items[3] + '-' + items[4]);
     if ( $(this).val() == 1 ) {
       $("#input-inpostoc3-receiver-selected-point-" + items[3] + '-' + items[4] ).prop('disabled', false);
+      $("#input-inpostoc3-receiver-selected-point-" + items[3] + '-' + items[4] ).prop('required', true);
+      $('#'+items[3] + '-' + items[4] +'-target-point').addClass('required');
     } else {
       $("#input-inpostoc3-receiver-selected-point-" + items[3] + '-' + items[4] ).prop('disabled', true);
+      $("#input-inpostoc3-receiver-selected-point-" + items[3] + '-' + items[4] ).prop('required', false);
+      $('#'+items[3] + '-' + items[4] +'-target-point').removeClass('required');
     }
     
     //console.log('index.php?route=extension/shipping/inpostoc3/sendingmethodsforservice&service_id=' + serviceId + '&user_token=' + getUserToken());
@@ -127,8 +131,12 @@ $(document).ready(function() {
     var items = $(this).attr('id').split('-');
     if ( $(this).val() == 1 ) {
       $("#input-inpostoc3-sender-selected-point-" + items[4] + '-' + items[5] ).prop('disabled', false);
+      $("#input-inpostoc3-sender-selected-point-" + items[3] + '-' + items[4] ).prop('required', true);
+      $('#'+items[3] + '-' + items[4] +'-dropoff-point').addClass('required');
     } else {
       $("#input-inpostoc3-sender-selected-point-" + items[4] + '-' + items[5] ).prop('disabled', true);
+      $("#input-inpostoc3-sender-selected-point-" + items[3] + '-' + items[4] ).prop('required', false);
+      $('#'+items[3] + '-' + items[4] +'-dropoff-point').removeClass('required');
     }
   });
 

--- a/upload/admin/view/javascript/inpostoc3.js
+++ b/upload/admin/view/javascript/inpostoc3.js
@@ -82,15 +82,17 @@ $(document).ready(function() {
     });
     
 
+    $(document).on('change', '[id^="input-inpostoc3-sending-method-"]', function() {
+      if ( $(this).val() == 1 ) {
+        $('[id^="input-inpostoc3-sender-selected-point-"]').prop('disabled', false);
+      } else {
+        $('[id^="input-inpostoc3-sender-selected-point-"]').prop('disabled', true);
+      }
+    });
+
 });
 
-$(document).on('change', '[id^="input-inpostoc3-sending-method-"]', function() {
-  if ( $(this).val() == 1 ) {
-    $('[id^="input-inpostoc3-sender-selected-point-"]').prop('disabled', false);
-  } else {
-    $('[id^="input-inpostoc3-sender-selected-point-"]').prop('disabled', true);
-  }
-});
+
 
 
 function getUserToken() {
@@ -98,3 +100,4 @@ function getUserToken() {
     var access_token = new URLSearchParams(url.search).get('user_token');
     return access_token;
 }
+

--- a/upload/admin/view/javascript/inpostoc3.js
+++ b/upload/admin/view/javascript/inpostoc3.js
@@ -1,0 +1,45 @@
+$(document).ready(function() {
+
+  //jQuery starts with
+  $('[id^="input-inpostoc3-service-"]').on('change',function() {
+    console.log('new: ' + $(this).attr('id') + '  ' + $(this).val());
+    var serviceId = $(this).val();
+    var items = $(this).attr('id').split('-');
+    var sending_method_eid = [];
+    sending_method_eid[0] = 'input-inpostoc3-sending-method';
+    sending_method_eid[1] = items[3] + '-' + items[4];
+    console.log('join :' + sending_method_eid.join('-'));
+    $("#" + sending_method_eid.join('-') ).empty();
+    $("#" + sending_method_eid.join('-') ).append(
+      "<option value=\"0\"> --- None --- </option>"
+    );
+    //console.log('index.php?route=extension/shipping/inpostoc3/sendingmethods&service_id=' + serviceId + '&user_token=' + getUserToken());
+    $.ajax({
+      url: 'index.php?route=extension/shipping/inpostoc3/sendingmethods&service_id=' + serviceId + '&user_token=' + getUserToken(),
+      type: 'get',
+      error: function(xhr, ajaxOptions, thrownError) {
+        alert(thrownError + "\r\n" + xhr.statusText + "\r\n" + xhr.responseText);
+      },
+      success: function(data, status) {
+        if ($.trim(data)){   
+          //console.log("What follows is not blank: " + data[serviceId]);
+          $.each( data, function( sId, serviceObj ) {
+            $.each (serviceObj, function(smId, smObj) {
+              $("#" + sending_method_eid.join('-') ).append(
+                "<option value=\""+ smObj.sending_method_id +"\">"+ smObj.description +"</option>"
+              );
+            });
+          });       
+        }
+      }
+    });
+  });
+
+});
+
+
+function getUserToken() {
+  var url = window.location;
+    var access_token = new URLSearchParams(url.search).get('user_token');
+    return access_token;
+}

--- a/upload/admin/view/javascript/inpostoc3.js
+++ b/upload/admin/view/javascript/inpostoc3.js
@@ -216,8 +216,10 @@ function easyPackWidget(data) {
   
   data.mapInit.mapType = geoWidgetDefaultMapType;
   data.mapInit.searchType = geoWidgetDefaultMapType;
-  data.countryIsoCode2 = $('#input-inpostoc3-' + data.who + '-addr-country-code-' + data.orderId + '-' + data.shipmentId).text().toLowerCase();
+  data.countryIsoCode2 = $('#input-inpostoc3-' + data.who + '-addr-country_iso_code_2-' + data.orderId + '-' + data.shipmentId).val().toLowerCase();
   if ( !geoWidgetDefaultLocale.includes(data.countryIsoCode2) ) {
+    console.log('element id: #input-inpostoc3-' + data.who + '-addr-country_iso_code_2-' + data.orderId + '-' + data.shipmentId);
+    console.log('element val: ' + $('#input-inpostoc3-' + data.who + '-addr-country_iso_code_2-' + data.orderId + '-' + data.shipmentId).val());
     throw new GeoWidgetError('Incorrect defaultLocale for GeoWidget = "' + data.countryIsoCode2 + '".Allowed defaultLocale values = [' + geoWidgetDefaultLocale + ']');
   }
   data.mapInit.defaultLocale = data.countryIsoCode2;

--- a/upload/admin/view/javascript/inpostoc3.js
+++ b/upload/admin/view/javascript/inpostoc3.js
@@ -1,21 +1,80 @@
+const animationDelay = 200;
+const geoWidgetSrcId = 'inpostoc3-geowidget-source';
+const geoWidgetStyleId = 'inpostoc3-geowidget-style';
+const geoWidgetScriptSrc = '<script src=\"https:\/\/geowidget.easypack24.net\/js\/sdk-for-javascript.js\" id=\"' + geoWidgetSrcId + '\"><\/script>';
+const geoWidgetStyleSrc = '<link rel=\"stylesheet\" href=\"https://geowidget.easypack24.net/css/easypack.css\" id=\"' + geoWidgetStyleId + '\" />';
+const geoWidgetDefaultMapType = 'osm';
+// use ajv or other JSONSchema based validator in future, share schema between catalog and admin
+/* const geoWidgetAllowedParameters = {
+  "defaultLocale": ['pl','uk'],
+  "locale": ['pl','uk','it'],
+  "mapType": ['osm','google'],
+  "searchType" : ['osm', 'google'],
+  "points" : {
+    "types": ['pop', 'parcel_locker', 'parcel_locker_only'],  # Options: parcel_locker_only, parcel_locker, pop    
+    "allowedToolTips": ['pok', 'pop'],
+    "functions": ['parcel','parcel_send','parcel_collect'] //avail. functions: parcel, parcel_send, parcel_collect
+  }, 
+  "map" : {
+     "googleKey": '', // required to use Google Maps API
+      "useGeolocation": true, // ['true','false'], default: true
+      "initialZoom": 13, // default: 13
+    "detailsMinZoom": 15, // minimum zoom after marker click
+    autocompleteZoom: 14,
+    visiblePointsMinZoom: 13,
+    "defaultLocation": [52.229807, 21.011595],
+    "initialTypes": ['pop', 'parcel_locker', 'parcel_locker_only'], // which type should be selected by default. Options: parcel_locker_only, parcel_locker, pop
+  },
+  "paymentFilter": {
+    "visible": ['true','false'], //default: false zezwala na wyświetlenie filtra płatnosć w paczkomacie
+    "defaultEnabled": ['true','false'], //default: false, włączony filtr dla płatności w paczkomacie już przy inicjalizacji
+    "showOnlyWithPayment": ['true','false'] //default: false, wymusza pokazywanie obiektów tylko z płatnością w paczkomacie
+  }
+}; // https://dokumentacja-inpost.atlassian.net/wiki/spaces/PL/pages/7438409/Geowidget+v4+User+s+Guide+New
+*/
+
 $(document).ready(function() {
 
+  $(geoWidgetScriptSrc).appendTo('head');
+  $(geoWidgetStyleSrc).insertAfter('#' + geoWidgetSrcId);
+
+  
+
+  $('[id^="input-inpostoc3-sender-selected-point-"]').on('click', function() {
+    var data = {};
+    data.buttonElementId = $(this).attr('id');
+    var items = $(this).attr('id').split('-');
+    data.orderId = items[5];
+    data.shipmentId = items[6];
+    data.countryIsoCode2 = $('#input-inpostoc3-sender-addr-country-code-' + data.orderId + '-' + data.shipmentId).text().toLowerCase();
+    console.log(easyPackWidget(data));
+    //openModal(data);
+  });
+  
   //jQuery starts with
   $('[id^="input-inpostoc3-service-"]').on('change',function() {
-    console.log('new: ' + $(this).attr('id') + '  ' + $(this).val());
+    //console.log('new: ' + $(this).attr('id') + '  ' + $(this).val());
     var serviceId = $(this).val();
     var items = $(this).attr('id').split('-');
     var sending_method_eid = [];
     sending_method_eid[0] = 'input-inpostoc3-sending-method';
     sending_method_eid[1] = items[3] + '-' + items[4];
-    console.log('join :' + sending_method_eid.join('-'));
+    //console.log('join :' + sending_method_eid.join('-'));
     $("#" + sending_method_eid.join('-') ).empty();
     $("#" + sending_method_eid.join('-') ).append(
       "<option value=\"0\"> --- None --- </option>"
     );
-    //console.log('index.php?route=extension/shipping/inpostoc3/sendingmethods&service_id=' + serviceId + '&user_token=' + getUserToken());
+    $("#" + sending_method_eid.join('-') +" option[value=\"0\"]").attr('selected','selected').change(); // imitate actual selection to trigger events
+    // console.log("input-inpostoc3-receiver-selected-point-" + items[3] + '-' + items[4]);
+    if ( $(this).val() == 1 ) {
+      $("#input-inpostoc3-receiver-selected-point-" + items[3] + '-' + items[4] ).prop('disabled', false);
+    } else {
+      $("#input-inpostoc3-receiver-selected-point-" + items[3] + '-' + items[4] ).prop('disabled', true);
+    }
+    
+    //console.log('index.php?route=extension/shipping/inpostoc3/sendingmethodsforservice&service_id=' + serviceId + '&user_token=' + getUserToken());
     $.ajax({
-      url: 'index.php?route=extension/shipping/inpostoc3/sendingmethods&service_id=' + serviceId + '&user_token=' + getUserToken(),
+      url: 'index.php?route=extension/shipping/inpostoc3/sendingmethodsforservice&service_id=' + serviceId + '&user_token=' + getUserToken(),
       type: 'get',
       error: function(xhr, ajaxOptions, thrownError) {
         alert(thrownError + "\r\n" + xhr.statusText + "\r\n" + xhr.responseText);
@@ -45,7 +104,7 @@ $(document).ready(function() {
       "order_id" : items[4],
       "shipment_id" : items[5] 
     };
-    var ending = items[5] + '-' + items[5];
+    var ending = items[4] + '-' + items[5];
     //console.log('shipment: ' + shipment["id"]);
     var sender_id = $(this).val();
 
@@ -81,14 +140,14 @@ $(document).ready(function() {
       });
     });
     
-
-    $(document).on('change', '[id^="input-inpostoc3-sending-method-"]', function() {
-      if ( $(this).val() == 1 ) {
-        $('[id^="input-inpostoc3-sender-selected-point-"]').prop('disabled', false);
-      } else {
-        $('[id^="input-inpostoc3-sender-selected-point-"]').prop('disabled', true);
-      }
-    });
+  $(document).on('change', '[id^="input-inpostoc3-sending-method-"]', function() {
+    var items = $(this).attr('id').split('-');
+    if ( $(this).val() == 1 ) {
+      $("#input-inpostoc3-sender-selected-point-" + items[4] + '-' + items[5] ).prop('disabled', false);
+    } else {
+      $("#input-inpostoc3-sender-selected-point-" + items[4] + '-' + items[5] ).prop('disabled', true);
+    }
+  });
 
 });
 
@@ -101,3 +160,77 @@ function getUserToken() {
     return access_token;
 }
 
+function reloadJs(src) {
+  src = $('script[src$="' + src + '"]').attr("src");
+  $('script[src$="' + src + '"]').remove();
+  $('<script/>').attr('src', src).appendTo('head');
+}
+
+function easyPackWidget(data) {
+  if ( !('mapInit' in data) ) {
+    data.mapInit = {};
+  }
+  data.mapInit.defaultLocale = data.countryIsoCode2;
+  data.mapInit.mapType = geoWidgetDefaultMapType;
+  data.mapInit.searchType = geoWidgetDefaultMapType;
+
+  if ( !('sendingMethod' in data) ) {
+    data.sendingMethod = {};
+  }
+  data.sendingMethod.id = $('#input-inpostoc3-sending-method-' + data.orderId + '-' + data.shipmentId ).val();
+  //console.log('#input-inpostoc3-sending-method-' + data.orderId + '-' + data.shipmentId + '.val():' + $('#input-inpostoc3-sending-method-' + data.orderId + '-' + data.shipmentId ).val() )
+  $.ajax({
+    url: 'index.php?route=extension/shipping/inpostoc3/sendingmethod&sending_method_id=' + data.sendingMethod.id + '&user_token=' + getUserToken(),
+    type: 'get',
+    error: function(xhr, ajaxOptions, thrownError) {
+      alert(thrownError + "\r\n" + xhr.statusText + "\r\n" + xhr.responseText);
+    },
+    success: function(retdata, status) {
+      if ($.trim(retdata)){   
+        //console.log("What follows is not blank: " + data[serviceId]);
+        $.each( retdata, function( smId, smObj ) {
+          console.log(smObj);
+          if (data.sendingMethod.id = smObj.id ) {
+            data.sendingMethod = smObj;
+            if ( data.sendingMethod.sending_method_identifier == 'parcel_locker' ) {
+              data.isDropOffPoint = true
+            }
+            if ( !('points' in data) ) {
+              data.mapInit.points = {};
+            }
+            data.mapInit.points.types = ['parcel_locker'];
+            if (data.isDropOffPoint) {
+              data.mapInit.points.functions = ['parcel_send'];
+            } else {
+              data.mapInit.points.functions = [];
+            }
+            if ( !('map' in data) ) {
+              data.mapInit.map = {};
+            }
+            data.mapInit.map.initialTypes = ['parcel_locker'];
+            return false; //ought to be only one, yet if that's not the case as a rule of thumb - first entry taken, break the loop
+          }
+        });  
+        console.log('before init: '); 
+        console.log(data);
+        // init
+        easyPack.init(data.mapInit);
+
+        // run modal 
+        openModal(data);
+        return data;    
+      }
+    }
+  });
+}
+
+function openModal(data) {
+  easyPack.modalMap(function(point, modal) {
+    modal.closeModal();
+    console.log(point);
+    if ( !('selectedPoint' in data) ) {
+      data.selectedPoint = {};
+    }
+    data.selectedPoint = point;
+  }, { width: 500, height: 600 });
+}

--- a/upload/admin/view/template/extension/shipping/inpostoc3.twig
+++ b/upload/admin/view/template/extension/shipping/inpostoc3.twig
@@ -104,7 +104,11 @@
                   <label class="col-sm-2 control-label" for="input-sendfrom-{{ geo_zone.geo_zone_id }}-{{ inpost_service.id}}"><span data-toggle="tooltip" title="{{ help_sendfrom }}">{{ entry_sendfrom }}</span></label>
                   <div class="col-sm-10">
                     <select name="shipping_inpostoc3_{{ geo_zone.geo_zone_id }}_{{inpost_service.id}}_sendfrom" id="input-sendfrom-{{ geo_zone.geo_zone_id }}-{{inpost_service.id}}" class="form-control">
-                      <option value="0">{{ text_none }}</option>
+                      <option value="0"
+                      {% if not shipping_inpostoc3_geo_zone_sendfrom[geo_zone.geo_zone_id][inpost_service.id] or shipping_inpostoc3_geo_zone_sendfrom[geo_zone.geo_zone_id][inpost_service.id] == 0 %}
+                      selected="selected"
+                      {% endif %}
+                      >{{ text_none }}</option>
                       {% for route in inpost_service.allowed_routes %}
                       <option value="{{ route.id }}" 
                         {% if shipping_inpostoc3_geo_zone_sendfrom[geo_zone.geo_zone_id][inpost_service.id] is same as (route.id) %}

--- a/upload/admin/view/template/extension/shipping/inpostoc3_api_shipping.twig
+++ b/upload/admin/view/template/extension/shipping/inpostoc3_api_shipping.twig
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html dir="{{ direction }}" lang="{{ lang }}">
+<head>
+  <meta charset="UTF-8" />
+  <title>{{ title }}</title>
+  <base href="{{ base }}" />
+  <link href="view/javascript/bootstrap/css/bootstrap.css" rel="stylesheet" media="all" />
+  <script type="text/javascript" src="view/javascript/jquery/jquery-2.1.1.min.js"></script>
+  <script type="text/javascript" src="view/javascript/bootstrap/js/bootstrap.min.js"></script>
+  <link href="view/javascript/font-awesome/css/font-awesome.min.css" type="text/css" rel="stylesheet" />
+  <link type="text/css" href="view/stylesheet/stylesheet.css" rel="stylesheet" media="all" />
+</head>
+<body>
+  <div class="container">
+    {{ error_warning }}
+    Teścik <br />
+    <div>
+      {{ api_resp }}
+      {{ entry_method }}
+      {{ posted }}
+    </div>
+  </div>
+</body>
+</html>

--- a/upload/admin/view/template/extension/shipping/inpostoc3_api_shipping.twig
+++ b/upload/admin/view/template/extension/shipping/inpostoc3_api_shipping.twig
@@ -14,15 +14,24 @@
   <div class="container">
     {{ error_warning }}
     <div>
-      {% if labels %}
-      {% for key, label in labels %}
-        {{ label }}
+      {% if orders %}
+      {% for order in orders %}
+        <div>
+          Order#{{ order.order_id }}
+          <ol>
+          {% for key, label in order.labels %}
+          <li><a href="{{ label.get_label_url }}" target="_blank">Get label for InPost shipment id {{ key }}</a></li>          
+          {% endfor %}
+          </ol>
+        </div>
       {% endfor %}
       {% else %}
       <div class="alert alert-danger alert-dismissible"><i class="fa fa-exclamation-circle"></i> {{ error_warning }}
-        Sorry, it seems the shipment label(s) is/are not ready yet. Please try again later.
         <button type="button" class="close" data-dismiss="alert">&times;</button>
       </div>
+      {% endif %}
+      {% if get_label %}
+      {{ get_label }}
       {% endif %}
     </div>
   </div>

--- a/upload/admin/view/template/extension/shipping/inpostoc3_api_shipping.twig
+++ b/upload/admin/view/template/extension/shipping/inpostoc3_api_shipping.twig
@@ -13,11 +13,17 @@
 <body>
   <div class="container">
     {{ error_warning }}
-    Teścik <br />
     <div>
-      {{ api_resp }}
-      {{ entry_method }}
-      {{ posted }}
+      {% if labels %}
+      {% for key, label in labels %}
+        {{ label }}
+      {% endfor %}
+      {% else %}
+      <div class="alert alert-danger alert-dismissible"><i class="fa fa-exclamation-circle"></i> {{ error_warning }}
+        Sorry, it seems the shipment label(s) is/are not ready yet. Please try again later.
+        <button type="button" class="close" data-dismiss="alert">&times;</button>
+      </div>
+      {% endif %}
     </div>
   </div>
 </body>

--- a/upload/admin/view/template/extension/shipping/inpostoc3_order_shipping.twig
+++ b/upload/admin/view/template/extension/shipping/inpostoc3_order_shipping.twig
@@ -468,6 +468,9 @@
                               <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
                               name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][country_iso_code_2]" id="input-inpostoc3-sender-addr-country_iso_code_2-{{order_id}}-{{ shipment.id }}"
                               value="{{ shipment.sender.country_iso_code_2 }}" >
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][country_iso_code_3]" id="input-inpostoc3-sender-addr-country_iso_code_3-{{order_id}}-{{ shipment.id }}"
+                              value="{{ shipment.sender.country_iso_code_3 }}" >
                             </div>
                           </div>
                         </td>
@@ -756,7 +759,10 @@
                               {{ shipment.receiver.country_iso_code_2 }}
                               <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
                               name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][country_iso_code_2]" id="input-inpostoc3-receiver-addr-country_iso_code_2-{{order_id}}-{{ shipment.id }}"
-                              value="{{ shipment.receiver.country_iso_code_2 }}" >                             
+                              value="{{ shipment.receiver.country_iso_code_2 }}" >  
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][country_iso_code_3]" id="input-inpostoc3-receiver-addr-country_iso_code_3-{{order_id}}-{{ shipment.id }}"
+                              value="{{ shipment.receiver.country_iso_code_3 }}" >                           
                             </div>
                           </div>
                         </td>
@@ -861,9 +867,23 @@
               <tr>
                 <td colspan="2" class="text-center">
                   <div class="pull-center">
+                    <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][status]" 
+                              id="input-inpostoc3-shipment-status-{{order_id}}-{{ shipment.id }}" 
+                              value="{{ shipment.status ?: null }}" >
                     {% if shipment.status is same as('draft') %}
                     <button type="submit" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" data-toggle="tooltip" title="{{ button_shipping_save }}" class="btn btn-primary" formaction="{{ attribute(_context,'action_save_' ~shipment.id ) }}" data-original-title="Save"><i class="fa fa-save"></i></button> 
                     {% endif %}
+                    {% if shipment.label_via_api_ready == true %}
+                    <a href="{{ attribute(_context,'action_dispatch_' ~shipment.id ) }}"
+                    target="_blank"
+                    data-toggle="tooltip" title="{{ button_shipping_print }}"
+                    class="btn btn-primary" 
+                    data-original-title="Print"
+                    id="print-link-{{ order_id }}-{{ shipment.id }}" >
+                    <i class="fa fa-truck"></i>
+                    </a>
+                    {% else %}
                     <button type="submit" 
                     form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" 
                     data-toggle="tooltip" title="{{ button_shipping_print }}" 
@@ -874,6 +894,7 @@
                     id="print-button-{{ order_id }}-{{ shipment.id }}">
                       <i class="fa fa-truck"></i>
                     </button>
+                    {% endif %}
                     <form method="post" enctype="multipart/form-data" id="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" class="col-md-12">
                     </form>
                   </div>

--- a/upload/admin/view/template/extension/shipping/inpostoc3_order_shipping.twig
+++ b/upload/admin/view/template/extension/shipping/inpostoc3_order_shipping.twig
@@ -67,10 +67,11 @@
                     </thead>
                     <tbody>
                       <tr>
-                        <td class="text-left">{{ text_service }}:</td>
+                        <td class="text-left col-md-4">{{ text_service }}:</td>
                         <td class="text-left">
                           {% if shipment.can_edit.sending_method_details %}
-                          <select form="form-inpostoc3-order-shipping-{{ order_id }}" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}">
+                          <select form="form-inpostoc3-order-shipping-{{ order_id }}" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}" style="
+                          width: 100%;">
                             <option value="0"
                             {% if not shipment.service_id or shipment.service_id == 0 %}
                             selected="selected"
@@ -90,17 +91,28 @@
                         </td>
                       </tr>
                       <tr>
-                        <td class="text-left">{{ text_sending_method }}:</td>
+                        <td class="text-left col-md-4">{{ text_sending_method }}:</td>
                         <td class="text-left">
                           {% if shipment.can_edit.sending_method_details %}
-                          <select form="form-inpostoc3-order-shipping-{{ order_id }}" id="input-inpostoc3-sending-method-{{order_id}}-{{ shipment.id }}">
+                          <select form="form-inpostoc3-order-shipping-{{ order_id }}" id="input-inpostoc3-sending-method-{{order_id}}-{{ shipment.id }}" style="
+                          width: 100%;">
                             <option value="0"
-                            {% if not shipment.service_id or shipment.service_id == 0 %}
+                            {% if not shipment.custom_attributes.sending_method %}
                             selected="selected"
                             {% endif %}
                             >{{ text_none }}</option>
-                            <!-- do java script stuff here to fill sending methods according to selected service -->
-                            {% endfor %}              
+                            {% for service in inpost_services %}
+                            {% if service.id == shipment.service_id %}
+                            {% for sending_method in service.sending_methods %}
+                            <option value="{{ sending_method.sending_method_id }}" 
+                            {% if shipment.custom_attributes.sending_method is same as (sending_method.sending_method_identifier) %}
+                            selected="selected"
+                            {% endif %}
+                            >{{ attribute(_context,'text_sending_method_' ~sending_method.sending_method_identifier) }}</option>
+                            {% endfor %}
+                            {% endif %}
+                            {% endfor %}
+                            <!-- after initial fill do the java script stuff here to fill sending methods according to selected service -->              
                           </select>
                           {% else %}
                           {{ attribute(_context,'text_' ~service.service_identifier~'_name')  }}

--- a/upload/admin/view/template/extension/shipping/inpostoc3_order_shipping.twig
+++ b/upload/admin/view/template/extension/shipping/inpostoc3_order_shipping.twig
@@ -307,11 +307,12 @@
                               {% endif %}                               
                             </div>
                           </div>
-                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
+                          <div class="form-group row form-inline {{ sender_country_postcode_required ? 'required' : '' }}" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-addr-post-code-{{order_id}}-{{ shipment.id }}">{{ text_addr_post_code }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
                               <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3-sender-addr-post-code-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-sender-addr-post-code-{{order_id}}-{{ shipment.id }}" 
+                              {{ sender_country_postcode_required ? 'required ' : '' }}
                               value="{{ shipment.sender_id ? shipment.sender.post_code : sender.post_code }}" 
                               placeholder="{{ text_addr_post_code }}"  class="form-control" style="width: 100%;" />
                               {% else %}
@@ -491,12 +492,13 @@
                               {% endif %}                               
                             </div>
                           </div>
-                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
+                          <div class="form-group row form-inline {{ sender_country_postcode_required ? 'required' : '' }}" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-addr-post-code-{{order_id}}-{{ shipment.id }}">{{ text_addr_post_code }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
                               <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3-receiver-addr-post-code-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-receiver-addr-post-code-{{order_id}}-{{ shipment.id }}" 
                               value="{{ shipment.receiver_id ? shipment.receiver.post_code : receiver.post_code }}" 
+                              {{ sender_country_postcode_required ? 'required ' : '' }}
                               placeholder="{{ text_addr_post_code }}"  class="form-control" style="width: 100%;" />
                               {% else %}
                               <span name="input-inpostoc3-receiver-addr-post-code-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.receiver.post_code }}</span>
@@ -506,7 +508,7 @@
                           <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-addr-country-code-{{order_id}}-{{ shipment.id }}">{{ text_addr_country_code }}</label>
                             <div class="col-md-9">
-                              <span name="input-inpostoc3-receiver-addr-country-code-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.receiver.country_iso_code_2 }}</span>                             
+                              <span name="input-inpostoc3-receiver-addr-country-code-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-receiver-addr-country-code-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.receiver.country_iso_code_2 }}</span>                             
                             </div>
                           </div>
                         </td>

--- a/upload/admin/view/template/extension/shipping/inpostoc3_order_shipping.twig
+++ b/upload/admin/view/template/extension/shipping/inpostoc3_order_shipping.twig
@@ -871,30 +871,34 @@
                               name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][status]" 
                               id="input-inpostoc3-shipment-status-{{order_id}}-{{ shipment.id }}" 
                               value="{{ shipment.status ?: null }}" >
-                    {% if shipment.status is same as('draft') %}
-                    <button type="submit" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" data-toggle="tooltip" title="{{ button_shipping_save }}" class="btn btn-primary" formaction="{{ attribute(_context,'action_save_' ~shipment.id ) }}" data-original-title="Save"><i class="fa fa-save"></i></button> 
-                    {% endif %}
-                    {% if shipment.label_via_api_ready == true %}
-                    <a href="{{ attribute(_context,'action_dispatch_' ~shipment.id ) }}"
-                    target="_blank"
-                    data-toggle="tooltip" title="{{ button_shipping_print }}"
-                    class="btn btn-primary" 
-                    data-original-title="Print"
-                    id="print-link-{{ order_id }}-{{ shipment.id }}" >
-                    <i class="fa fa-truck"></i>
-                    </a>
-                    {% else %}
-                    <button type="submit" 
-                    form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" 
-                    data-toggle="tooltip" title="{{ button_shipping_print }}" 
-                    class="btn btn-primary" 
-                    formaction="{{ attribute(_context,'action_dispatch_' ~shipment.id ) }}" 
-                    formtarget="_blank"
-                    data-original-title="Print"
-                    id="print-button-{{ order_id }}-{{ shipment.id }}">
+                    {% if not shipment.tracking_url %}
+                      {% if shipment.status is same as('draft') %}
+                      <button type="submit" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" data-toggle="tooltip" title="{{ button_shipping_save }}" class="btn btn-primary" formaction="{{ attribute(_context,'action_save_' ~shipment.id ) }}" data-original-title="Save"><i class="fa fa-save"></i></button> 
+                      {% endif %}
+                      {% if shipment.label_via_api_ready == true %}
+                      <a href="{{ attribute(_context,'action_dispatch_' ~shipment.id ) }}"
+                      target="_blank"
+                      data-toggle="tooltip" title="{{ button_shipping_print }}"
+                      class="btn btn-primary" 
+                      data-original-title="Print"
+                      id="print-link-{{ order_id }}-{{ shipment.id }}" >
                       <i class="fa fa-truck"></i>
-                    </button>
-                    {% endif %}
+                      </a>
+                      {% else %}
+                      <button type="submit" 
+                      form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" 
+                      data-toggle="tooltip" title="{{ button_shipping_print }}" 
+                      class="btn btn-primary" 
+                      formaction="{{ attribute(_context,'action_dispatch_' ~shipment.id ) }}" 
+                      formtarget="_blank"
+                      data-original-title="Print"
+                      id="print-button-{{ order_id }}-{{ shipment.id }}">
+                        <i class="fa fa-truck"></i>
+                      </button>
+                      {% endif %}
+                    {% else %}
+                    <a href="{{shipment.tracking_url}}" target="_blank">{{shipment.tracking_url}}</a>
+                    {% endif %} 
                     <form method="post" enctype="multipart/form-data" id="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" class="col-md-12">
                     </form>
                   </div>

--- a/upload/admin/view/template/extension/shipping/inpostoc3_order_shipping.twig
+++ b/upload/admin/view/template/extension/shipping/inpostoc3_order_shipping.twig
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="pull-right">
-        {% if inpostoc3_can_edit_shipment %}
+        {% if inpostoc3_can_edit.shipment %}
         <button type="submit" form="form-inpostoc3-order-shipping" data-toggle="tooltip" title="{{ button_save }}" class="btn btn-primary" formaction="{{ action_save }}"><i class="fa fa-save"></i></button>
         {% endif %}
         <!-- <button type="submit" form="form-inpostoc3-order-shipping" data-toggle="tooltip" title="{{ button_shipping_print }}" class="btn btn-primary" formaction="{{ action_dispatch }}"><i class="fa fa-truck"></i></button> -->
@@ -24,11 +24,10 @@
     </div>
     {% endif %}
     {% if shipping_code_inpostoc3_used %}
-    <!-- Shipments -->
     <div class="panel panel-default">
       <div class="panel-heading">
         <h3 class="panel-title"><i class="fa 
-        {% if inpostoc3_can_edit_shipment %}
+        {% if inpostoc3_can_edit.shipment %}
         fa-pencil
         {% else %}
         fa-info-circle
@@ -37,49 +36,8 @@
       </div>
     </div>
 
-    <div class="row">
-      <div class="col-md-4">
-        <div class="panel panel-default">
-          <div class="panel-heading">
-            <h3 class="panel-title">{{ text_sending_method_details }}</h3>
-          </div>
-          <table class="table">
-            <tbody>
-              <tr></tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-      <div class="col-md-4">
-        <div class="panel panel-default">
-          <div class="panel-heading">
-            <h3 class="panel-title">{{ text_send_from }}</h3>
-          </div>
-          <table class="table">
-            <tbody>
-              <tr></tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-      <div class="col-md-4">
-        <div class="panel panel-default">
-          <div class="panel-heading">
-            <h3 class="panel-title">{{ text_send_to }}</h3>
-          </div>
-          <table class="table">
-            <tbody>
-              <tr></tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-    </div>
-
-    <div class="row">
-      <div id="inpost-geowidget" style="display: none;"></div>
-    </div>
-
+    
+    <!-- Shipments -->
     <div class="panel panel-default">
       <div class="panel-heading">
         <h3 class="panel-title"><i class="fa fa-list"></i>{{ text_shipments }}</h3>
@@ -88,7 +46,7 @@
         <!-- foreach shipment display div with shipment data + table with parcels-->
         <div class="align-items-center">
           <table class="table table-bordered">
-            <thead style="background-color: #f6f6f6;">
+            <thead style="background-color: #f6f6f6;" class="panel-title">
               <tr>
                 <td class="text-left text-uppercase">
                   {{ text_shipment_number }}: numerek tutaj
@@ -100,6 +58,75 @@
               </tr>
             </thead>
             <tbody>
+              <tr>
+                <td colspan="3">
+                  
+                  <table class="table table-condensed" style="width:33%; float: left;" id="shipment-{{ order_id }}">
+                    <thead>
+                      <tr><td colspan="2">{{ text_sending_method_details }}</td></tr>
+                    </thead>
+                    <tbody>
+                      <tr>
+                        <td>{{ text_service }}:</td>
+                        <td>
+                          {% if inpostoc3_can_edit.service_method_details %}
+                          <select form="form-inpostoc3-order-shipping-{{ order_id }}" id="input-inpostoc3-service-{{order_id}}">
+              
+                          </select>
+                          {% else %}
+                          {% endif %}
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+
+                  <table class="table table-condensed" style="width:33%; float: left;" id="shipment-{{ order_id }}">
+                    <thead>
+                      <tr><td colspan="2">{{ text_send_from }}</td></tr>
+                    </thead>
+                    <tbody>
+                      <tr>
+                        <td>{{ text_service }}:</td>
+                        <td>
+                          {% if inpostoc3_can_edit.service_method_details %}
+                          <select form="form-inpostoc3-order-shipping-{{ order_id }}" id="input-inpostoc3-service-{{order_id}}">
+              
+                          </select>
+                          {% else %}
+                          {% endif %}
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+
+                  <table class="table table-condensed" style="width:33%; float: left;" id="shipment-{{ order_id }}">
+                    <thead>
+                      <tr><td colspan="2">{{ text_send_to }}</td></tr>
+                    </thead>
+                    <tbody>
+                      <tr>
+                        <td>{{ text_service }}:</td>
+                        <td>
+                          {% if inpostoc3_can_edit.service_method_details %}
+                          <select form="form-inpostoc3-order-shipping-{{ order_id }}" id="input-inpostoc3-service-{{order_id}}">
+              
+                          </select>
+                          {% else %}
+                          {% endif %}
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+
+                  <div id="inpost-geowidget" style="display: none;"></div>
+                </td>
+
+                
+
+              </tr>
+              <tr>
+
+              </tr>
               <tr>
                 <td colspan="3">
                   <table class="table table-md table-hover">
@@ -115,7 +142,7 @@
                       <!--for each parcel generate tr-->
                       <tr>
                         <td class="text-left">
-                          {% if inpostoc3_can_edit_shipment %}
+                          {% if inpostoc3_can_edit.shipment %}
                           <select>
                             <option>opcja</option>
                           </select>
@@ -145,7 +172,7 @@
       </div>
     </div>
 
-    {% if inpostoc3_can_edit_shipment %}
+    {% if inpostoc3_can_edit.shipment %}
     <form method="post" enctype="multipart/form-data" id="form-inpostoc3-order-shipping-{{ order_id }}" class="col-md-12">
     </form>
     {% endif %}

--- a/upload/admin/view/template/extension/shipping/inpostoc3_order_shipping.twig
+++ b/upload/admin/view/template/extension/shipping/inpostoc3_order_shipping.twig
@@ -72,7 +72,7 @@
                           <label class="col-md-2 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}">{{ text_service }}</label>
                           <div class="col-md-10">
                             {% if shipment.can_edit.sending_method_details %}
-                            <select form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}" class="form-control" style="width: 100%;">
+                            <select form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}" class="form-control" style="width: 100%;">
                               <option value="0"
                               {% if not shipment.service_id or shipment.service_id == 0 %}
                               selected="selected"
@@ -95,7 +95,7 @@
                           <label class="col-md-2 control-label" for="input-inpostoc3-sending-method-{{order_id}}-{{ shipment.id }}">{{ text_sending_method }}</label>
                           <div class="col-md-10">
                             {% if shipment.can_edit.sending_method_details %}
-                            <select form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-sending-method-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-sending-method-{{order_id}}-{{ shipment.id }}" class="form-control" style="width: 100%;">
+                            <select form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-sending-method-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-sending-method-{{order_id}}-{{ shipment.id }}" class="form-control" style="width: 100%;">
                               <option value="0"
                               {% if not shipment.custom_attributes.sending_method %}
                               selected="selected"
@@ -124,7 +124,7 @@
                     </tbody>
                   </table>
 
-                  <table class="table table-condensed" style="width:33%; float: left;" id="shipment-{{ order_id }}">
+                  <table class="table table-condensed" style="width:33%; float: left; background-color: #f6f6f6;" id="{{ order_id }}-{{ shipment.id }}-shipment">
                     <thead>
                       <tr><td>{{ text_send_from }}</td></tr>
                     </thead>
@@ -132,147 +132,197 @@
                       <tr>
                         <td class="text-left">
                           <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;" id="{{ order_id }}-{{ shipment.id }}-dropoff-point">
-                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-selected-point">{{ text_selected_sending_point }}</label>
+                            <label class="col-md-3 control-label" for="input-inpostoc3-sender-selected-point-{{order_id}}-{{ shipment.id }}">{{ text_selected_sending_point }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="button" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-selected-point" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-selected-point" 
+                              <input type="button" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3-sender-selected-point-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-sender-selected-point-{{order_id}}-{{ shipment.id }}" 
                               value=
                               {% if shipment.custom_attributes.dropoff_point is empty %}
                               "{{ text_click_to_select }}" 
                               {% else %}
                               "{{ shipment.custom_attributes.dropoff_point }}" 
                               {% endif %}
+                              {% if shipment.custom_attributes.sending_method is not same as("parcel_locker") %}
+                              disabled 
+                              {% endif %}
                               class="btn btn-primary form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-selected-point" class="form-control">{{ shipment.custom_attributes.dropoff_point }}</span>
+                              <span name="input-inpostoc3-sender-selected-point-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.custom_attributes.dropoff_point }}</span>
                               {% endif %}                              
                             </div>
                           </div>
 
+                          {% if shipment.can_edit.sending_method_details %}
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                            <div class="col-md-12">
+                              <select  name="input-inpostoc3-select-sender-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-select-sender-{{order_id}}-{{ shipment.id }}" class="form-control" style="width: 100%;">
+                              <option value="0"
+                              {% if not shipment.sender_id %}
+                              selected="selected"
+                              {% endif %}
+                              >{{ text_addr_new }}</option>
+                              
+                              {% for a_sender in senders %}
+                              <option value="{{ a_sender.id }}" 
+                              {% if shipment.sender_id is same as (a_sender.id) %}
+                              selected="selected"
+                              {% endif %}
+                              >{{ a_sender.name ?: entry_name }}</option>
+                              {% endfor %}
+                              </select>
+                            </div>
+                          </div>
+						              {% endif %}
+
+
                           <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
-                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-name">{{ text_name }}</label>
+                            <label class="col-md-3 control-label" for="input-inpostoc3-sender-name-{{order_id}}-{{ shipment.id }}">{{ text_name }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-name" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-name" value="{{ sender.name }}" placeholder="{{ text_name }}"  class="form-control" style="width: 100%;" />
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-sender-name-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-sender-name-{{order_id}}-{{ shipment.id }}" 
+                              value="{{ shipment.sender_id ? shipment.sender.name : sender.name }}"
+                              placeholder="{{ text_name }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-name" class="form-control">{{ shipment.sender.name }}</span>
+                              <span name="input-inpostoc3-{{order_id}}-{{ shipment.id }}-sender-name" class="form-control">{{ shipment.sender.name }}</span>
                               {% endif %}     
                             </div>
                           </div>
                           <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
-                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-company-name">{{ text_company_name }}</label>
+                            <label class="col-md-3 control-label" for="input-inpostoc3-sender-company-name-{{order_id}}-{{ shipment.id }}">{{ text_company_name }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-company-name" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-company-name" value="{{ sender.company_name }}" placeholder="{{ text_company_name }}"  class="form-control" style="width: 100%;" />
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3-sender-company-name-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-sender-company-name-{{order_id}}-{{ shipment.id }}" 
+                              value="{{ shipment.sender_id ? shipment.sender.company_name : sender.company_name }}"
+                              placeholder="{{ text_company_name }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-company-name" class="form-control">{{ shipment.sender.company_name }}</span>
+                              <span name="input-inpostoc3-sender-company-name-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.sender.company_name }}</span>
                               {% endif %}                              
                             </div>
                           </div>
                           <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
-                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-first-name">{{ text_first_name }}</label>
+                            <label class="col-md-3 control-label" for="input-inpostoc3-sender-first-name-{{order_id}}-{{ shipment.id }}">{{ text_first_name }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-first-name" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-first-name" value="{{ sender.first_name }}" placeholder="{{ text_first_name }}"  class="form-control" style="width: 100%;" />
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-sender-first-name-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-sender-first-name-{{order_id}}-{{ shipment.id }}" 
+                              value="{{ shipment.sender_id ? shipment.sender.first_name : sender.first_name }}"
+                              placeholder="{{ text_first_name }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-first-name" class="form-control">{{ shipment.sender.first_name }}</span>
+                              <span name="input-inpostoc3-sender-first-name-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.sender.first_name }}</span>
                               {% endif %}                              
                             </div>
                           </div>
                           <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
-                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-last-name">{{ text_last_name }}</label>
+                            <label class="col-md-3 control-label" for="input-inpostoc3-sender-last-name-{{order_id}}-{{ shipment.id }}">{{ text_last_name }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-last-name" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-last-name" value="{{ sender.last_name }}" placeholder="{{ text_last_name }}"  class="form-control" style="width: 100%;" />
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-sender-last-name-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-sender-last-name-{{order_id}}-{{ shipment.id }}" 
+                              value="{{ shipment.sender_id ? shipment.sender.last_name : sender.last_name }}"  
+                              placeholder="{{ text_last_name }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-last-name" class="form-control">{{ shipment.sender.last_name }}</span>
+                              <span name="input-inpostoc3-sender-last-name-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.sender.last_name }}</span>
                               {% endif %}                                  
                             </div>
                           </div>
                           <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
-                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-phone">{{ text_phone }}</label>
+                            <label class="col-md-3 control-label" for="input-inpostoc3-sender-phone-{{order_id}}-{{ shipment.id }}">{{ text_phone }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-phone" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-phone" value="{{ sender.phone }}" placeholder="{{ text_phone }}"  class="form-control" style="width: 100%;" />
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-sender-phone-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-sender-phone-{{order_id}}-{{ shipment.id }}" 
+                              value="{{ shipment.sender_id ? shipment.sender.phone : sender.phone }}" 
+                              placeholder="{{ text_phone }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-phone" class="form-control">{{ shipment.sender.phone }}</span>
+                              <span name="input-inpostoc3-sender-phone-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.sender.phone }}</span>
                               {% endif %}                         
                             </div>
                           </div>
                           <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
-                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-email">{{ text_email }}</label>
+                            <label class="col-md-3 control-label" for="input-inpostoc3-sender-email-{{order_id}}-{{ shipment.id }}">{{ text_email }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-email" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-email" value="{{ sender.email }}" placeholder="{{ text_email }}"  class="form-control" style="width: 100%;" />
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-sender-email-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-sender-email-{{order_id}}-{{ shipment.id }}" 
+                              value="{{ shipment.sender_id ? shipment.sender.email : sender.email }}" 
+                              placeholder="{{ text_email }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-email" class="form-control">{{ shipment.sender.email }}</span>
+                              <span name="input-inpostoc3-sender-email-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.sender.email }}</span>
                               {% endif %}                              
                             </div>                            
                           </div>
                           <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
-                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-street">{{ text_addr_street }}</label>
+                            <label class="col-md-3 control-label" for="input-inpostoc3-sender-addr-street-{{order_id}}-{{ shipment.id }}">{{ text_addr_street }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-street" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-street" value="{{ sender.street }}" placeholder="{{ text_addr_street }}"  class="form-control" style="width: 100%;" />
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-sender-addr-street-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-sender-addr-street-{{order_id}}-{{ shipment.id }}" 
+                              value="{{ shipment.sender_id ? shipment.sender.street : sender.street }}" 
+                              placeholder="{{ text_addr_street }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-street" class="form-control">{{ shipment.sender.street }}</span>
+                              <span name="input-inpostoc3-sender-addr-street-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.sender.street }}</span>
                               {% endif %}                              
                             </div>
                           </div>
                           <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
-                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-building-number">{{ text_addr_building_number }}</label>
+                            <label class="col-md-3 control-label" for="input-inpostoc3-sender-addr-building-number-{{order_id}}-{{ shipment.id }}">{{ text_addr_building_number }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-building-number" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-building-number" value="{{ sender.building_number }}" placeholder="{{ text_addr_building_number }}"  class="form-control" style="width: 100%;" />
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-sender-addr-building-number-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-sender-addr-building-number-{{order_id}}-{{ shipment.id }}" 
+                              value="{{ shipment.sender_id ? shipment.sender.building_number : sender.building_number }}" 
+                              placeholder="{{ text_addr_building_number }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-building-number" class="form-control">{{ shipment.sender.building_number }}</span>
+                              <span name="input-inpostoc3-sender-addr-building-number-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.sender.building_number }}</span>
                               {% endif %}                                
                             </div>
                           </div>
                           <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
-                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-line-1">{{ text_addr_line_1 }}</label>
+                            <label class="col-md-3 control-label" for="input-inpostoc3-sender-addr-line-1-{{order_id}}-{{ shipment.id }}">{{ text_addr_line_1 }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-line-1" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-line-1" value="{{ sender.line1 }}" placeholder="{{ text_addr_line_1 }}"  class="form-control" style="width: 100%;" />
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3-sender-addr-line-1-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-sender-addr-line-1-{{order_id}}-{{ shipment.id }}" 
+                              value="{{ shipment.sender_id ? shipment.sender.line1 : sender.line1 }}" 
+                              placeholder="{{ text_addr_line_1 }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-line-1" class="form-control">{{ shipment.sender.line1 }}</span>
+                              <span name="input-inpostoc3-sender-addr-line-1-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.sender.line1 }}</span>
                               {% endif %}                                
                             </div>
                           </div>
                           <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
-                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-line-2">{{ text_addr_line_2 }}</label>
+                            <label class="col-md-3 control-label" for="input-inpostoc3-sender-addr-line-2-{{order_id}}-{{ shipment.id }}">{{ text_addr_line_2 }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-line-2" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-line-2" value="{{ sender.line2 }}" placeholder="{{ text_addr_line_2 }}"  class="form-control" style="width: 100%;" />
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3-sender-addr-line-2-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-sender-addr-line-2-{{order_id}}-{{ shipment.id }}" 
+                              value="{{ shipment.sender_id ? shipment.sender.line2 : sender.line2 }}" 
+                              placeholder="{{ text_addr_line_2 }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-line-2" class="form-control">{{ shipment.sender.line2 }}</span>
+                              <span name="input-inpostoc3-sender-addr-line-2-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.sender.line2 }}</span>
                               {% endif %}                                
                             </div>
                           </div>
                           <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
-                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-city">{{ text_addr_city }}</label>
+                            <label class="col-md-3 control-label" for="input-inpostoc3-sender-addr-city-{{order_id}}-{{ shipment.id }}">{{ text_addr_city }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-city" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-city" value="{{ sender.city }}" placeholder="{{ text_addr_city }}"  class="form-control" style="width: 100%;" />
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-sender-addr-city-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-sender-addr-city-{{order_id}}-{{ shipment.id }}" 
+                              value="{{ shipment.sender_id ? shipment.sender.city : sender.city }}" 
+                              placeholder="{{ text_addr_city }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-city" class="form-control">{{ shipment.sender.city }}</span>
+                              <span name="input-inpostoc3-sender-addr-city-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.sender.city }}</span>
                               {% endif %}                               
                             </div>
                           </div>
                           <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
-                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-post-code">{{ text_addr_post_code }}</label>
+                            <label class="col-md-3 control-label" for="input-inpostoc3-sender-addr-post-code-{{order_id}}-{{ shipment.id }}">{{ text_addr_post_code }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-post-code" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-post-code" value="{{ sender.post_code }}" placeholder="{{ text_addr_post_code }}"  class="form-control" style="width: 100%;" />
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3-sender-addr-post-code-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-sender-addr-post-code-{{order_id}}-{{ shipment.id }}" 
+                              value="{{ shipment.sender_id ? shipment.sender.post_code : sender.post_code }}" 
+                              placeholder="{{ text_addr_post_code }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-post-code" class="form-control">{{ shipment.sender.post_code }}</span>
+                              <span name="input-inpostoc3-sender-addr-post-code-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.sender.post_code }}</span>
                               {% endif %}                             
                             </div>
                           </div>
                           <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
-                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-country-code">{{ text_addr_country_code }}</label>
+                            <label class="col-md-3 control-label" for="input-inpostoc3-sender-addr-country-code-{{order_id}}-{{ shipment.id }}">{{ text_addr_country_code }}</label>
                             <div class="col-md-9">
-                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-country-code" class="form-control">{{ shipment.sender.country_iso_code_2 }}</span>                             
+                              <span name="input-inpostoc3-sender-addr-country-code-{{order_id}}-{{ shipment.id }}" class="form-control" id="input-inpostoc3-sender-addr-country-code-{{order_id}}-{{ shipment.id }}">{{ shipment.sender.country_iso_code_2 }}</span>                             
                             </div>
                           </div>
                         </td>
@@ -289,10 +339,10 @@
                       <tr>
                         <td class="text-left">
                           <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;" id="{{ order_id }}-{{ shipment.id }}-target-point">
-                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-selected-point">{{ text_selected_target_point }}</label>
+                            <label class="col-md-3 control-label" for="input-inpostoc3-{{order_id}}-{{ shipment.id }}-receiver-selected-point">{{ text_selected_target_point }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="button" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-selected-point" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-selected-point" 
+                              <input type="button" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3-{{order_id}}-{{ shipment.id }}-receiver-selected-point" id="input-inpostoc3-{{order_id}}-{{ shipment.id }}-receiver-selected-point" 
                               value=
                               {% if shipment.custom_attributes.target_point is empty %}
                               "{{ text_click_to_select }}" 
@@ -301,135 +351,159 @@
                               {% endif %}
                               class="btn btn-primary form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-selected-point" class="form-control">{{ shipment.custom_attributes.target_point }}</span>
+                              <span name="input-inpostoc3-{{order_id}}-{{ shipment.id }}-receiver-selected-point" class="form-control">{{ shipment.custom_attributes.target_point }}</span>
                               {% endif %}                              
                             </div>
                           </div>
 
                           <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
-                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-name">{{ text_name }}</label>
+                            <label class="col-md-3 control-label" for="input-inpostoc3-receiver-name-{{order_id}}-{{ shipment.id }}">{{ text_name }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-name" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-name" value="{{ receiver.name }}" placeholder="{{ text_name }}"  class="form-control" style="width: 100%;" />
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-receiver-name-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-receiver-name-{{order_id}}-{{ shipment.id }}" 
+                              value="{{ shipment.receiver_id ? shipment.receiver.name : receiver.name }}" 
+                              placeholder="{{ text_name }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-name" class="form-control">{{ shipment.receiver.name }}</span>
+                              <span name="input-inpostoc3-receiver-name-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.receiver.name }}</span>
                               {% endif %}     
                             </div>
                           </div>
-                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
-                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-company-name">{{ text_company_name }}</label>
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                            <label class="col-md-3 control-label" for="input-inpostoc3-receiver-company-name-{{order_id}}-{{ shipment.id }}">{{ text_company_name }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-company-name" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-company-name" value="{{ receiver.company_name }}" placeholder="{{ text_company_name }}"  class="form-control" style="width: 100%;" />
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3-receiver-company-name-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-receiver-company-name-{{order_id}}-{{ shipment.id }}" 
+                              value="{{ shipment.receiver_id ? shipment.receiver.company_name : receiver.company_name }}"
+                              placeholder="{{ text_company_name }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-company-name" class="form-control">{{ shipment.receiver.company_name }}</span>
+                              <span name="input-inpostoc3-receiver-company-name-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.receiver.company_name }}</span>
                               {% endif %}                              
                             </div>
                           </div>
                           <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
-                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-first-name">{{ text_first_name }}</label>
+                            <label class="col-md-3 control-label" for="input-inpostoc3-receiver-first-name-{{order_id}}-{{ shipment.id }}">{{ text_first_name }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-first-name" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-first-name" value="{{ receiver.first_name }}" placeholder="{{ text_first_name }}"  class="form-control" style="width: 100%;" />
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-receiver-first-name-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-receiver-first-name-{{order_id}}-{{ shipment.id }}" 
+                              value="{{ shipment.receiver_id ? shipment.receiver.first_name : receiver.first_name }}"
+                              placeholder="{{ text_first_name }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-first-name" class="form-control">{{ shipment.receiver.first_name }}</span>
+                              <span name="input-inpostoc3-receiver-first-name-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.receiver.first_name }}</span>
                               {% endif %}                              
                             </div>
                           </div>
                           <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
-                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-last-name">{{ text_last_name }}</label>
+                            <label class="col-md-3 control-label" for="input-inpostoc3-receiver-last-name-{{order_id}}-{{ shipment.id }}">{{ text_last_name }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-last-name" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-last-name" value="{{ receiver.last_name }}" placeholder="{{ text_last_name }}"  class="form-control" style="width: 100%;" />
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-receiver-last-name-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-receiver-last-name-{{order_id}}-{{ shipment.id }}" 
+                              value="{{ shipment.receiver_id ? shipment.receiver.last_name : receiver.last_name }}"
+                              placeholder="{{ text_last_name }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-last-name" class="form-control">{{ shipment.receiver.last_name }}</span>
+                              <span name="input-inpostoc3-receiver-last-name-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.receiver.last_name }}</span>
                               {% endif %}                                  
                             </div>
                           </div>
                           <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
-                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-phone">{{ text_phone }}</label>
+                            <label class="col-md-3 control-label" for="input-inpostoc3-receiver-phone-{{order_id}}-{{ shipment.id }}">{{ text_phone }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-phone" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-phone" value="{{ receiver.phone }}" placeholder="{{ text_phone }}"  class="form-control" style="width: 100%;" />
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-receiver-phone-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-receiver-phone-{{order_id}}-{{ shipment.id }}" 
+                              value="{{ shipment.receiver_id ? shipment.receiver.phone : receiver.phone }}"
+                              placeholder="{{ text_phone }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-phone" class="form-control">{{ shipment.receiver.phone }}</span>
+                              <span name="input-inpostoc3-receiver-phone-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.receiver.phone }}</span>
                               {% endif %}                         
                             </div>
                           </div>
                           <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
-                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-email">{{ text_email }}</label>
+                            <label class="col-md-3 control-label" for="input-inpostoc3-receiver-email-{{order_id}}-{{ shipment.id }}">{{ text_email }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-email" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-email" value="{{ receiver.email }}" placeholder="{{ text_email }}"  class="form-control" style="width: 100%;" />
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-receiver-email-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-receiver-email-{{order_id}}-{{ shipment.id }}" 
+                              value="{{ shipment.receiver_id ? shipment.receiver.email : receiver.email }}"
+                              placeholder="{{ text_email }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-email" class="form-control">{{ shipment.receiver.email }}</span>
+                              <span name="input-inpostoc3-receiver-email-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.receiver.email }}</span>
                               {% endif %}                              
                             </div>                            
                           </div>
                           <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
-                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-street">{{ text_addr_street }}</label>
+                            <label class="col-md-3 control-label" for="input-inpostoc3-receiver-addr-street-{{order_id}}-{{ shipment.id }}">{{ text_addr_street }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-street" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-street" value="{{ receiver.street }}" placeholder="{{ text_addr_street }}"  class="form-control" style="width: 100%;" />
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-receiver-addr-street-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-receiver-addr-street-{{order_id}}-{{ shipment.id }}" 
+                              value="{{ shipment.receiver_id ? shipment.receiver.street : receiver.street }}"
+                              placeholder="{{ text_addr_street }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-street" class="form-control">{{ shipment.receiver.street }}</span>
+                              <span name="input-inpostoc3-receiver-addr-street-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.receiver.street }}</span>
                               {% endif %}                              
                             </div>
                           </div>
                           <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
-                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-building-number">{{ text_addr_building_number }}</label>
+                            <label class="col-md-3 control-label" for="input-inpostoc3-receiver-addr-building-number-{{order_id}}-{{ shipment.id }}">{{ text_addr_building_number }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-building-number" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-building-number" value="{{ receiver.building_number }}" placeholder="{{ text_addr_building_number }}"  class="form-control" style="width: 100%;" />
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-receiver-addr-building-number-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-receiver-addr-building-number-{{order_id}}-{{ shipment.id }}" 
+                              value="{{ shipment.receiver_id ? shipment.receiver.building_number : receiver.building_number }}" 
+                              placeholder="{{ text_addr_building_number }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-building-number" class="form-control">{{ shipment.receiver.building_number }}</span>
+                              <span name="input-inpostoc3-receiver-addr-building-number-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.receiver.building_number }}</span>
                               {% endif %}                                
                             </div>
                           </div>
                           <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
-                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-line-1">{{ text_addr_line_1 }}</label>
+                            <label class="col-md-3 control-label" for="input-inpostoc3-receiver-addr-line-1-{{order_id}}-{{ shipment.id }}">{{ text_addr_line_1 }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-line-1" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-line-1" value="{{ receiver.line1 }}" placeholder="{{ text_addr_line_1 }}"  class="form-control" style="width: 100%;" />
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3-receiver-addr-line-1-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-receiver-addr-line-1-{{order_id}}-{{ shipment.id }}" 
+                              value="{{ shipment.receiver_id ? shipment.receiver.line1 : receiver.line1 }}" 
+                              placeholder="{{ text_addr_line_1 }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-line-1" class="form-control">{{ shipment.receiver.line1 }}</span>
+                              <span name="input-inpostoc3-receiver-addr-line-1-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.receiver.line1 }}</span>
                               {% endif %}                                
                             </div>
                           </div>
                           <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
-                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-line-2">{{ text_addr_line_2 }}</label>
+                            <label class="col-md-3 control-label" for="input-inpostoc3-receiver-addr-line-2-{{order_id}}-{{ shipment.id }}">{{ text_addr_line_2 }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-line-2" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-line-2" value="{{ receiver.line2 }}" placeholder="{{ text_addr_line_2 }}"  class="form-control" style="width: 100%;" />
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3-receiver-addr-line-2-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-receiver-addr-line-2-{{order_id}}-{{ shipment.id }}" 
+                              value="{{ shipment.receiver_id ? shipment.receiver.line2 : receiver.line2 }}" 
+                              placeholder="{{ text_addr_line_2 }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-line-2" class="form-control">{{ shipment.receiver.line2 }}</span>
+                              <span name="input-inpostoc3-receiver-addr-line-2-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.receiver.line2 }}</span>
                               {% endif %}                                
                             </div>
                           </div>
                           <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
-                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-city">{{ text_addr_city }}</label>
+                            <label class="col-md-3 control-label" for="input-inpostoc3-receiver-addr-city-{{order_id}}-{{ shipment.id }}">{{ text_addr_city }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-city" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-city" value="{{ receiver.city }}" placeholder="{{ text_addr_city }}"  class="form-control" style="width: 100%;" />
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-receiver-addr-city-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-receiver-addr-city-{{order_id}}-{{ shipment.id }}" 
+                              value="{{ shipment.receiver_id ? shipment.receiver.city :  receiver.city }}" 
+                              placeholder="{{ text_addr_city }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-city" class="form-control">{{ shipment.receiver.city }}</span>
+                              <span name="input-inpostoc3-receiver-addr-city-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.receiver.city }}</span>
                               {% endif %}                               
                             </div>
                           </div>
                           <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
-                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-post-code">{{ text_addr_post_code }}</label>
+                            <label class="col-md-3 control-label" for="input-inpostoc3-receiver-addr-post-code-{{order_id}}-{{ shipment.id }}">{{ text_addr_post_code }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-post-code" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-post-code" value="{{ receiver.post_code }}" placeholder="{{ text_addr_post_code }}"  class="form-control" style="width: 100%;" />
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3-receiver-addr-post-code-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-receiver-addr-post-code-{{order_id}}-{{ shipment.id }}" 
+                              value="{{ shipment.receiver_id ? shipment.receiver.post_code : receiver.post_code }}" 
+                              placeholder="{{ text_addr_post_code }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-post-code" class="form-control">{{ shipment.receiver.post_code }}</span>
+                              <span name="input-inpostoc3-receiver-addr-post-code-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.receiver.post_code }}</span>
                               {% endif %}                             
                             </div>
                           </div>
                           <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
-                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-country-code">{{ text_addr_country_code }}</label>
+                            <label class="col-md-3 control-label" for="input-inpostoc3-receiver-addr-country-code-{{order_id}}-{{ shipment.id }}">{{ text_addr_country_code }}</label>
                             <div class="col-md-9">
-                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-country-code" class="form-control">{{ shipment.receiver.country_iso_code_2 }}</span>                             
+                              <span name="input-inpostoc3-receiver-addr-country-code-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.receiver.country_iso_code_2 }}</span>                             
                             </div>
                           </div>
                         </td>
@@ -458,15 +532,28 @@
                     </thead>
                     <tbody>
                       <!--for each parcel generate tr-->
+                      {% for parcel in shipment.parcels %}
                       <tr>
                         <td class="text-left">
-                          {% if inpostoc3_can_edit.shipment %}
-                          <select>
-                            <option>opcja</option>
-                          </select>
-                          {% else %}
-                          {{ text_template_description }}
-                          {% endif %}
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                            <div class="col-md-12">
+                              <select  name="input-inpostoc3-parcel-{{order_id}}-{{ shipment.id }}-{{ parcel.id }}" id="input-inpostoc3-parcel-{{order_id}}-{{ shipment.id }}-{{ parcel.id }}" class="form-control" style="width: 100%;">
+                              <option value="0"
+                              {% if not parcel.id %}
+                              selected="selected"
+                              {% endif %}
+                              >{{ text_none }}</option>
+                              
+                              {% for parcel_template in parcel_templates %}
+                              <option value="{{ parcel_template.id }}" 
+                              {% if parcel.template_id is same as (parcel_template.id) %}
+                              selected="selected"
+                              {% endif %}
+                              >{{ parcel_template.template_identifier }}</option>
+                              {% endfor %}
+                              </select>
+                            </div>
+                          </div>
                         </td>
                         <td class="text-left">{{ text_parcel_number }}
 
@@ -476,6 +563,7 @@
                         </td>
                         <td></td>
                       </tr>
+                      {% endfor %}
                       <!-- future: add as a last row in table ability to add parcels to shipment if this is not inpost_locker_service and not yet shipped/registered via API-->
                     </tbody>
                   </table>

--- a/upload/admin/view/template/extension/shipping/inpostoc3_order_shipping.twig
+++ b/upload/admin/view/template/extension/shipping/inpostoc3_order_shipping.twig
@@ -44,22 +44,22 @@
       </div>
       <div class="panel-body">
         <!-- foreach shipment display div with shipment data + table with parcels-->
-        <div class="align-items-center">
+        {% for shipment in shipments %}
+        <div class="align-items-center" id="shipment-{{ shipment.id }}">
           <table class="table table-bordered">
             <thead style="background-color: #f6f6f6;" class="panel-title">
               <tr>
                 <td class="text-left text-uppercase">
-                  {{ text_shipment_number }}: numerek tutaj
+                  {{ text_shipment_number }}: {{ shipment.number ?: text_none }}
                 </td>
                 <td class="text-left text-uppercase">
-                  {{ text_shipment_tracking_number }}: numerek tutaj
+                  {{ text_shipment_tracking_number }}: {{ shipment.tracking_number ?: text_none }}
                 </td>
-                <td></td>
               </tr>
             </thead>
             <tbody>
               <tr>
-                <td colspan="3">
+                <td colspan="2">
                   
                   <table class="table table-condensed" style="width:33%; float: left;" id="shipment-{{ order_id }}">
                     <thead>
@@ -67,13 +67,43 @@
                     </thead>
                     <tbody>
                       <tr>
-                        <td>{{ text_service }}:</td>
-                        <td>
-                          {% if inpostoc3_can_edit.service_method_details %}
-                          <select form="form-inpostoc3-order-shipping-{{ order_id }}" id="input-inpostoc3-service-{{order_id}}">
-              
+                        <td class="text-left">{{ text_service }}:</td>
+                        <td class="text-left">
+                          {% if shipment.can_edit.sending_method_details %}
+                          <select form="form-inpostoc3-order-shipping-{{ order_id }}" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}">
+                            <option value="0"
+                            {% if not shipment.service_id or shipment.service_id == 0 %}
+                            selected="selected"
+                            {% endif %}
+                            >{{ text_none }}</option>
+                            {% for service in inpost_services %}
+                            <option value="{{ service.id }}" 
+                              {% if shipment.service_id is same as (service.id) %}
+                              selected="selected"
+                              {% endif %}
+                            >{{ attribute(_context,'text_' ~service.service_identifier~'_name') }}</option>
+                            {% endfor %}              
                           </select>
                           {% else %}
+                          {{ attribute(_context,'text_' ~service.service_identifier~'_name')  }}
+                          {% endif %}
+                        </td>
+                      </tr>
+                      <tr>
+                        <td class="text-left">{{ text_sending_method }}:</td>
+                        <td class="text-left">
+                          {% if shipment.can_edit.sending_method_details %}
+                          <select form="form-inpostoc3-order-shipping-{{ order_id }}" id="input-inpostoc3-sending-method-{{order_id}}-{{ shipment.id }}">
+                            <option value="0"
+                            {% if not shipment.service_id or shipment.service_id == 0 %}
+                            selected="selected"
+                            {% endif %}
+                            >{{ text_none }}</option>
+                            <!-- do java script stuff here to fill sending methods according to selected service -->
+                            {% endfor %}              
+                          </select>
+                          {% else %}
+                          {{ attribute(_context,'text_' ~service.service_identifier~'_name')  }}
                           {% endif %}
                         </td>
                       </tr>
@@ -86,10 +116,11 @@
                     </thead>
                     <tbody>
                       <tr>
-                        <td>{{ text_service }}:</td>
-                        <td>
+                        <td class="text-left">{{ text_service }}:</td>
+                        <td class="text-left">
                           {% if inpostoc3_can_edit.service_method_details %}
                           <select form="form-inpostoc3-order-shipping-{{ order_id }}" id="input-inpostoc3-service-{{order_id}}">
+                            
               
                           </select>
                           {% else %}
@@ -105,8 +136,8 @@
                     </thead>
                     <tbody>
                       <tr>
-                        <td>{{ text_service }}:</td>
-                        <td>
+                        <td class="text-left">{{ text_service }}:</td>
+                        <td class="text-left">
                           {% if inpostoc3_can_edit.service_method_details %}
                           <select form="form-inpostoc3-order-shipping-{{ order_id }}" id="input-inpostoc3-service-{{order_id}}">
               
@@ -118,7 +149,6 @@
                     </tbody>
                   </table>
 
-                  <div id="inpost-geowidget" style="display: none;"></div>
                 </td>
 
                 
@@ -128,7 +158,7 @@
 
               </tr>
               <tr>
-                <td colspan="3">
+                <td colspan="2">
                   <table class="table table-md table-hover">
                     <thead>
                       <tr>
@@ -168,7 +198,7 @@
 
         </div>
         <!-- add ability to add another shipment to order in future, for orders split to a couple of shipments and shipment not registered yet via API-->
-        
+        {% endfor %}
       </div>
     </div>
 

--- a/upload/admin/view/template/extension/shipping/inpostoc3_order_shipping.twig
+++ b/upload/admin/view/template/extension/shipping/inpostoc3_order_shipping.twig
@@ -49,7 +49,7 @@
     <!-- Shipments -->
     <div class="panel panel-default">
       <div class="panel-heading">
-        <h3 class="panel-title"><i class="fa fa-list"></i>{{ text_shipments }}</h3>
+        <h3 class="panel-title"><i class="fa fa-list"></i>{{ text_shipments }} ({{ text_order }}#{{ order_id }})</h3>
       </div>
       <div class="panel-body">
         <!-- foreach shipment display div with shipment data + table with parcels-->

--- a/upload/admin/view/template/extension/shipping/inpostoc3_order_shipping.twig
+++ b/upload/admin/view/template/extension/shipping/inpostoc3_order_shipping.twig
@@ -32,20 +32,6 @@
     </div>
     {% endif %}
     {% if shipping_code_inpostoc3_used %}
-    <!-- <div class="panel panel-default">
-      <div class="panel-heading">
-        <h3 class="panel-title"><i class="fa 
-        {% if inpostoc3_can_edit_order %}
-        fa-pencil
-        {% else %}
-        fa-info-circle
-        {% endif %}
-        "></i>Order (#{{ order_id }})</h3>
-      </div>
-    </div>
-     -->
-
-    
     <!-- Shipments -->
     <div class="panel panel-default">
       <div class="panel-heading">
@@ -54,6 +40,9 @@
       <div class="panel-body">
         <!-- foreach shipment display div with shipment data + table with parcels-->
         {% for shipment in shipments %}
+        <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+        name="input-inpostoc3[{{order_id}}][geo_zone_id]" id="input-inpostoc3-shipment-order-geo_zone_id-{{order_id}}-{{ shipment.id }}"
+        value="{{ shipping_code_inpostoc3_geo_zone_id }}" >
         <div class="align-items-center" id="shipment-{{ shipment.id }}">
           <table class="table table-bordered">
             <thead style="background-color: #f6f6f6;" class="panel-title">
@@ -286,11 +275,19 @@
                               {% endif %}                              
                             </div>                            
                           </div>
-                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
+                          <div class="form-group row form-inline 
+                          {% if shipment.sender.street or shipment.sender.building_number %}
+                          required
+                          {% endif %}
+                          " style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;" id="input-inpostoc3-sender-addr_street_row-{{order_id}}-{{ shipment.id }}">
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-addr-street-{{order_id}}-{{ shipment.id }}">{{ text_addr_street }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][street]" id="input-inpostoc3-sender-addr-street-{{order_id}}-{{ shipment.id }}" 
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" 
+                              {% if shipment.sender.street or shipment.sender.building_number %}
+                              required 
+                              {% endif %}
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][street]" id="input-inpostoc3-sender-addr-street-{{order_id}}-{{ shipment.id }}" 
                               value="{{ shipment.sender_id ? shipment.sender.street : sender.street }}" 
                               placeholder="{{ text_addr_street }}"  class="form-control" style="width: 100%;" />
                               {% else %}
@@ -298,11 +295,19 @@
                               {% endif %}                              
                             </div>
                           </div>
-                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
-                            <label class="col-md-3 control-label" for="input-inpostoc3-sender-addr-building-number-{{order_id}}-{{ shipment.id }}">{{ text_addr_building_number }}</label>
+                          <div class="form-group row form-inline
+                          {% if shipment.sender.street or shipment.sender.building_number %}
+                          required
+                          {% endif %}
+                          " style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;" id="input-inpostoc3-sender-addr_building_number_row-{{order_id}}-{{ shipment.id }}">
+                            <label class="col-md-3 control-label" for="input-inpostoc3-sender-addr-building_number-{{order_id}}-{{ shipment.id }}">{{ text_addr_building_number }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][building_number]" id="input-inpostoc3-sender-addr-building-number-{{order_id}}-{{ shipment.id }}" 
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" 
+                              {% if shipment.sender.street or shipment.sender.building_number %}
+                              required 
+                              {% endif %} 
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][building_number]" id="input-inpostoc3-sender-addr-building_number-{{order_id}}-{{ shipment.id }}" 
                               value="{{ shipment.sender_id ? shipment.sender.building_number : sender.building_number }}" 
                               placeholder="{{ text_addr_building_number }}"  class="form-control" style="width: 100%;" />
                               {% else %}
@@ -310,11 +315,18 @@
                               {% endif %}                                
                             </div>
                           </div>
-                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
+                          <div class="form-group row form-inline
+                          {% if not (shipment.sender.street or shipment.sender.building_number) and shipment.sender.line1 %}
+                          required
+                          {% endif %}
+                          " style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;" id="input-inpostoc3-sender-addr_line_1_row-{{order_id}}-{{ shipment.id }}">
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-addr-line-1-{{order_id}}-{{ shipment.id }}">{{ text_addr_line_1 }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
                               <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][line1]" id="input-inpostoc3-sender-addr-line-1-{{order_id}}-{{ shipment.id }}" 
+                              {% if not (shipment.sender.street or shipment.sender.building_number) and shipment.sender.line1 %}
+                              required 
+                              {% endif %}
                               value="{{ shipment.sender_id ? shipment.sender.line1 : sender.line1 }}" 
                               placeholder="{{ text_addr_line_1 }}"  class="form-control" style="width: 100%;" />
                               {% else %}
@@ -322,11 +334,18 @@
                               {% endif %}                                
                             </div>
                           </div>
-                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
+                          <div class="form-group row form-inline
+                          {% if not (shipment.sender.street or shipment.sender.building_number) and shipment.sender.line2 %}
+                          required
+                          {% endif %}
+                          " style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;" id="input-inpostoc3-sender-addr_line_2_row-{{order_id}}-{{ shipment.id }}">
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-addr-line-2-{{order_id}}-{{ shipment.id }}">{{ text_addr_line_2 }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
                               <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][line2]" id="input-inpostoc3-sender-addr-line-2-{{order_id}}-{{ shipment.id }}" 
+                              {% if not (shipment.sender.street or shipment.sender.building_number) and shipment.sender.line2 %}
+                              required
+                              {% endif %}
                               value="{{ shipment.sender_id ? shipment.sender.line2 : sender.line2 }}" 
                               placeholder="{{ text_addr_line_2 }}"  class="form-control" style="width: 100%;" />
                               {% else %}
@@ -362,7 +381,10 @@
                           <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-addr-country-code-{{order_id}}-{{ shipment.id }}">{{ text_addr_country_code }}</label>
                             <div class="col-md-9">
-                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][country_iso_code_2]" class="form-control" id="input-inpostoc3-sender-addr-country-code-{{order_id}}-{{ shipment.id }}">{{ shipment.sender.country_iso_code_2 }}</span>                             
+                              <span class="form-control" id="input-inpostoc3-sender-addr-country-code-{{order_id}}-{{ shipment.id }}">{{ shipment.sender.country_iso_code_2 }}</span>                             
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][country_iso_code_2]" id="input-inpostoc3-sender-addr-country_iso_code_2-{{order_id}}-{{ shipment.id }}"
+                              value="{{ shipment.sender.country_iso_code_2 }}" >
                             </div>
                           </div>
                         </td>
@@ -479,11 +501,19 @@
                               {% endif %}                              
                             </div>                            
                           </div>
-                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
+                          <div class="form-group row form-inline
+                          {% if (shipment.receiver.street or shipment.receiver.building_number) %}
+                          required 
+                          {% endif %}
+                          " style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;" id="input-inpostoc3-receiver-addr_street_row-{{order_id}}-{{ shipment.id }}">
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-addr-street-{{order_id}}-{{ shipment.id }}">{{ text_addr_street }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][street]" id="input-inpostoc3-receiver-addr-street-{{order_id}}-{{ shipment.id }}" 
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" 
+                              {% if (shipment.receiver.street or shipment.receiver.building_number) %}
+                              required 
+                              {% endif %} 
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][street]" id="input-inpostoc3-receiver-addr-street-{{order_id}}-{{ shipment.id }}" 
                               value="{{ shipment.receiver_id ? shipment.receiver.street : receiver.street }}"
                               placeholder="{{ text_addr_street }}"  class="form-control" style="width: 100%;" />
                               {% else %}
@@ -491,11 +521,19 @@
                               {% endif %}                              
                             </div>
                           </div>
-                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
-                            <label class="col-md-3 control-label" for="input-inpostoc3-receiver-addr-building-number-{{order_id}}-{{ shipment.id }}">{{ text_addr_building_number }}</label>
+                          <div class="form-group row form-inline
+                          {% if (shipment.receiver.street or shipment.receiver.building_number) %}
+                          required 
+                          {% endif %}
+                          " style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;" id="input-inpostoc3-receiver-addr_building_number_row-{{order_id}}-{{ shipment.id }}">
+                            <label class="col-md-3 control-label" for="input-inpostoc3-receiver-addr-building_number-{{order_id}}-{{ shipment.id }}">{{ text_addr_building_number }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][building_number]" id="input-inpostoc3-receiver-addr-building-number-{{order_id}}-{{ shipment.id }}" 
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" 
+                              {% if (shipment.receiver.street or shipment.receiver.building_number) %}
+                              required 
+                              {% endif %}
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][building_number]" id="input-inpostoc3-receiver-addr-building_number-{{order_id}}-{{ shipment.id }}" 
                               value="{{ shipment.receiver_id ? shipment.receiver.building_number : receiver.building_number }}" 
                               placeholder="{{ text_addr_building_number }}"  class="form-control" style="width: 100%;" />
                               {% else %}
@@ -503,11 +541,18 @@
                               {% endif %}                                
                             </div>
                           </div>
-                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
+                          <div class="form-group row form-inline
+                          {% if not (shipment.receiver.street or shipment.receiver.building_number) and shipment.receiver.line1 %}
+                          required 
+                          {% endif %}
+                          " style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;" id="input-inpostoc3-receiver-addr_line_1_row-{{order_id}}-{{ shipment.id }}">
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-addr-line-1-{{order_id}}-{{ shipment.id }}">{{ text_addr_line_1 }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
                               <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][line1]" id="input-inpostoc3-receiver-addr-line-1-{{order_id}}-{{ shipment.id }}" 
+                              {% if not (shipment.receiver.street or shipment.receiver.building_number) and shipment.receiver.line1 %}
+                              required 
+                              {% endif %}
                               value="{{ shipment.receiver_id ? shipment.receiver.line1 : receiver.line1 }}" 
                               placeholder="{{ text_addr_line_1 }}"  class="form-control" style="width: 100%;" />
                               {% else %}
@@ -515,11 +560,18 @@
                               {% endif %}                                
                             </div>
                           </div>
-                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
+                          <div class="form-group row form-inline
+                          {% if not (shipment.receiver.street or shipment.receiver.building_number) and shipment.receiver.line2 %}
+                          required 
+                          {% endif %}
+                          " style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;" id="input-inpostoc3-receiver-addr_line_2_row-{{order_id}}-{{ shipment.id }}">
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-addr-line-2-{{order_id}}-{{ shipment.id }}">{{ text_addr_line_2 }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
                               <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][line2]" id="input-inpostoc3-receiver-addr-line-2-{{order_id}}-{{ shipment.id }}" 
+                              {% if not (shipment.receiver.street or shipment.receiver.building_number) and shipment.receiver.line2 %}
+                              required 
+                              {% endif %}
                               value="{{ shipment.receiver_id ? shipment.receiver.line2 : receiver.line2 }}" 
                               placeholder="{{ text_addr_line_2 }}"  class="form-control" style="width: 100%;" />
                               {% else %}
@@ -555,7 +607,10 @@
                           <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-addr-country-code-{{order_id}}-{{ shipment.id }}">{{ text_addr_country_code }}</label>
                             <div class="col-md-9">
-                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][country_iso_code_2]" id="input-inpostoc3-receiver-addr-country-code-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.receiver.country_iso_code_2 }}</span>                             
+                              <span id="input-inpostoc3-receiver-addr-country-code-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.receiver.country_iso_code_2 }}</span>
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][country_iso_code_2]" id="input-inpostoc3-receiver-addr-country_iso_code_2-{{order_id}}-{{ shipment.id }}"
+                              value="{{ shipment.sender.country_iso_code_2 }}" >                             
                             </div>
                           </div>
                         </td>
@@ -660,9 +715,18 @@
                 <td colspan="2" class="text-center">
                   <div class="pull-center">
                     {% if shipment.status is same as('draft') %}
-                    <button type="submit" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" data-toggle="tooltip" title="{{ button_shipping_save }}" class="btn btn-primary" formaction="{{ action_save }}" data-original-title="Save"><i class="fa fa-save"></i></button> 
+                    <button type="submit" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" data-toggle="tooltip" title="{{ button_shipping_save }}" class="btn btn-primary" formaction="{{ attribute(_context,'action_save_' ~shipment.id ) }}" data-original-title="Save"><i class="fa fa-save"></i></button> 
                     {% endif %}
-                    <button type="submit" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" data-toggle="tooltip" title="{{ button_shipping_print }}" class="btn btn-primary" formaction=""><i class="fa fa-truck"></i></button>
+                    <button type="submit" 
+                    form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" 
+                    data-toggle="tooltip" title="{{ button_shipping_print }}" 
+                    class="btn btn-primary" 
+                    formaction="{{ attribute(_context,'action_dispatch_' ~shipment.id ) }}" 
+                    formtarget="_blank"
+                    data-original-title="Print"
+                    id="print-button-{{ order_id }}-{{ shipment.id }}">
+                      <i class="fa fa-truck"></i>
+                    </button>
                     <form method="post" enctype="multipart/form-data" id="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" class="col-md-12">
                     </form>
                   </div>

--- a/upload/admin/view/template/extension/shipping/inpostoc3_order_shipping.twig
+++ b/upload/admin/view/template/extension/shipping/inpostoc3_order_shipping.twig
@@ -14,13 +14,6 @@
     </div>
   </div>
   <div class="container-fluid">
-    <!--
-    <ol>
-      {% for key, value in _context  %}
-        <li>{{ key }} </li>
-      {% endfor %}
-  </ol>
-  -->
     {% if error_warning %}
     <div class="alert alert-danger alert-dismissible"><i class="fa fa-exclamation-circle"></i> {{ error_warning }}
       <button type="button" class="close" data-dismiss="alert">&times;</button>
@@ -49,9 +42,15 @@
               <tr>
                 <td class="text-left text-uppercase">
                   {{ text_shipment_number }}: {{ shipment.number ?: text_none }}
+                  <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                  name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][number]" id="input-inpostoc3-shipment-order-shipment-number-{{order_id}}-{{ shipment.id }}"
+                  value="{{ shipment.number ?: null }}" >
                 </td>
                 <td class="text-left text-uppercase">
                   {{ text_shipment_tracking_number }}: {{ shipment.tracking_number ?: text_none }}
+                  <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                  name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][tracking_number]" id="input-inpostoc3-shipment-order-shipment-tracking_number-{{order_id}}-{{ shipment.id }}"
+                  value="{{ shipment.tracking_number ?: null }}" >
                 </td>
               </tr>
             </thead>
@@ -219,7 +218,6 @@
                           </div>
 						              {% endif %}
 
-
                           <div class="form-group row form-inline 
                           {% if shipment.can_edit.sending_method_details %}
                           required
@@ -255,11 +253,18 @@
                               value="{{ shipment.sender_id ? shipment.sender.company_name : sender.company_name }}"
                               placeholder="{{ text_company_name }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][company_name]" class="form-control">{{ shipment.sender.company_name }}</span>
+                                {{ shipment.sender.company_name }}
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][company_name]" id="input-inpostoc3-sender-company-name-{{order_id}}-{{ shipment.id }}"
+                              value="{{ shipment.sender.company_name }}" >
                               {% endif %}                              
                             </div>
                           </div>
-                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
+                          <div class="form-group row form-inline 
+                          {% if shipment.can_edit.sending_method_details %}
+                          required
+                          {% endif %}
+                          " style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-first-name-{{order_id}}-{{ shipment.id }}">{{ text_first_name }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -267,11 +272,18 @@
                               value="{{ shipment.sender_id ? shipment.sender.first_name : sender.first_name }}"
                               placeholder="{{ text_first_name }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][first_name]" class="form-control">{{ shipment.sender.first_name }}</span>
+                                {{ shipment.sender.first_name }}
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][first_name]" id="input-inpostoc3-sender-first-name-{{order_id}}-{{ shipment.id }}"
+                              value="{{ shipment.sender.first_name }}" >
                               {% endif %}                              
                             </div>
                           </div>
-                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
+                          <div class="form-group row form-inline 
+                          {% if shipment.can_edit.sending_method_details %}
+                          required
+                          {% endif %}
+                          " style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-last-name-{{order_id}}-{{ shipment.id }}">{{ text_last_name }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -279,11 +291,18 @@
                               value="{{ shipment.sender_id ? shipment.sender.last_name : sender.last_name }}"  
                               placeholder="{{ text_last_name }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][last_name]" class="form-control">{{ shipment.sender.last_name }}</span>
+                                {{ shipment.sender.last_name }}
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][last_name]" id="input-inpostoc3-sender-last-name-{{order_id}}-{{ shipment.id }}"
+                              value="{{ shipment.sender.last_name }}" >
                               {% endif %}                                  
                             </div>
                           </div>
-                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
+                          <div class="form-group row form-inline 
+                          {% if shipment.can_edit.sending_method_details %}
+                          required
+                          {% endif %}
+                          " style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-phone-{{order_id}}-{{ shipment.id }}">{{ text_phone }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -291,11 +310,18 @@
                               value="{{ shipment.sender_id ? shipment.sender.phone : sender.phone }}" 
                               placeholder="{{ text_phone }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][phone]" class="form-control">{{ shipment.sender.phone }}</span>
+                                {{ shipment.sender.phone }}
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][phone]" id="input-inpostoc3-sender-phone-{{order_id}}-{{ shipment.id }}"
+                              value="{{ shipment.sender.phone }}" >
                               {% endif %}                         
                             </div>
                           </div>
-                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
+                          <div class="form-group row form-inline
+                          {% if shipment.can_edit.sending_method_details %} 
+                          required
+                          {% endif %}
+                          " style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-email-{{order_id}}-{{ shipment.id }}">{{ text_email }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -303,12 +329,15 @@
                               value="{{ shipment.sender_id ? shipment.sender.email : sender.email }}" 
                               placeholder="{{ text_email }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][email]" class="form-control">{{ shipment.sender.email }}</span>
+                                {{ shipment.sender.email }}
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][email]" id="input-inpostoc3-sender-email-{{order_id}}-{{ shipment.id }}"
+                              value="{{ shipment.sender.email }}" >
                               {% endif %}                              
                             </div>                            
                           </div>
                           <div class="form-group row form-inline 
-                          {% if shipment.sender.street or shipment.sender.building_number %}
+                          {% if (shipment.sender.street or shipment.sender.building_number) and shipment.can_edit.sending_method_details %}
                           required
                           {% endif %}
                           " style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;" id="input-inpostoc3-sender-addr_street_row-{{order_id}}-{{ shipment.id }}">
@@ -323,12 +352,15 @@
                               value="{{ shipment.sender_id ? shipment.sender.street : sender.street }}" 
                               placeholder="{{ text_addr_street }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][street]" class="form-control">{{ shipment.sender.street }}</span>
+                                {{ shipment.sender.street }}
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][street]" id="input-inpostoc3-sender-addr-street-{{order_id}}-{{ shipment.id }}" 
+                              value="{{ shipment.sender.street }}" >
                               {% endif %}                              
                             </div>
                           </div>
                           <div class="form-group row form-inline
-                          {% if shipment.sender.street or shipment.sender.building_number %}
+                          {% if (shipment.sender.street or shipment.sender.building_number) and shipment.can_edit.sending_method_details %}
                           required
                           {% endif %}
                           " style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;" id="input-inpostoc3-sender-addr_building_number_row-{{order_id}}-{{ shipment.id }}">
@@ -343,12 +375,15 @@
                               value="{{ shipment.sender_id ? shipment.sender.building_number : sender.building_number }}" 
                               placeholder="{{ text_addr_building_number }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][building_number]" class="form-control">{{ shipment.sender.building_number }}</span>
+                                {{ shipment.sender.building_number }}
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][building_number]" id="input-inpostoc3-sender-addr-building_number-{{order_id}}-{{ shipment.id }}" 
+                              value="{{ shipment.sender.building_number }}" >
                               {% endif %}                                
                             </div>
                           </div>
                           <div class="form-group row form-inline
-                          {% if not (shipment.sender.street or shipment.sender.building_number) and shipment.sender.line1 %}
+                          {% if not (shipment.sender.street or shipment.sender.building_number) and shipment.sender.line1 and shipment.can_edit.sending_method_details %}
                           required
                           {% endif %}
                           " style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;" id="input-inpostoc3-sender-addr_line_1_row-{{order_id}}-{{ shipment.id }}">
@@ -362,12 +397,15 @@
                               value="{{ shipment.sender_id ? shipment.sender.line1 : sender.line1 }}" 
                               placeholder="{{ text_addr_line_1 }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][line1]" class="form-control">{{ shipment.sender.line1 }}</span>
+                              {{ shipment.sender.line1 }}
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][line1]" id="input-inpostoc3-sender-addr-line-1-{{order_id}}-{{ shipment.id }}"
+                              value="{{ shipment.sender.line1 }}" >
                               {% endif %}                                
                             </div>
                           </div>
                           <div class="form-group row form-inline
-                          {% if not (shipment.sender.street or shipment.sender.building_number) and shipment.sender.line2 %}
+                          {% if not (shipment.sender.street or shipment.sender.building_number) and shipment.sender.line2 and shipment.can_edit.sending_method_details %}
                           required
                           {% endif %}
                           " style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;" id="input-inpostoc3-sender-addr_line_2_row-{{order_id}}-{{ shipment.id }}">
@@ -381,11 +419,18 @@
                               value="{{ shipment.sender_id ? shipment.sender.line2 : sender.line2 }}" 
                               placeholder="{{ text_addr_line_2 }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][line2]" class="form-control">{{ shipment.sender.line2 }}</span>
+                              {{ shipment.sender.line2 }}
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][line2]" id="input-inpostoc3-sender-addr-line-2-{{order_id}}-{{ shipment.id }}"
+                              value="{{ shipment.sender.line2 }}" >
                               {% endif %}                                
                             </div>
                           </div>
-                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
+                          <div class="form-group row form-inline 
+                          {% if shipment.can_edit.sending_method_details %}
+                          required
+                          {% endif %}
+                          " style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-addr-city-{{order_id}}-{{ shipment.id }}">{{ text_addr_city }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -393,11 +438,14 @@
                               value="{{ shipment.sender_id ? shipment.sender.city : sender.city }}" 
                               placeholder="{{ text_addr_city }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][city]" class="form-control">{{ shipment.sender.city }}</span>
+                              {{ shipment.sender.city }}
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][city]" id="input-inpostoc3-sender-addr-city-{{order_id}}-{{ shipment.id }}"
+                              value="{{ shipment.sender.city }}" >
                               {% endif %}                               
                             </div>
                           </div>
-                          <div class="form-group row form-inline {{ sender_country_postcode_required ? 'required' : '' }}" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
+                          <div class="form-group row form-inline {{ (sender_country_postcode_required and shipment.can_edit.sending_method_details) ? 'required' : '' }}" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-addr-post-code-{{order_id}}-{{ shipment.id }}">{{ text_addr_post_code }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -406,14 +454,17 @@
                               value="{{ shipment.sender_id ? shipment.sender.post_code : sender.post_code }}" 
                               placeholder="{{ text_addr_post_code }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][post_code]" class="form-control">{{ shipment.sender.post_code }}</span>
+                              {{ shipment.sender.post_code }}
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][post_code]" id="input-inpostoc3-sender-addr-post-code-{{order_id}}-{{ shipment.id }}"
+                              value="{{ shipment.sender.post_code }}" >
                               {% endif %}                             
                             </div>
                           </div>
                           <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-addr-country-code-{{order_id}}-{{ shipment.id }}">{{ text_addr_country_code }}</label>
                             <div class="col-md-9">
-                              <span class="form-control" id="input-inpostoc3-sender-addr-country-code-{{order_id}}-{{ shipment.id }}">{{ shipment.sender.country_iso_code_2 }}</span>                             
+                              {{ shipment.sender.country_iso_code_2 }}                             
                               <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
                               name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][country_iso_code_2]" id="input-inpostoc3-sender-addr-country_iso_code_2-{{order_id}}-{{ shipment.id }}"
                               value="{{ shipment.sender.country_iso_code_2 }}" >
@@ -491,11 +542,18 @@
                               value="{{ shipment.receiver_id ? shipment.receiver.company_name : receiver.company_name }}"
                               placeholder="{{ text_company_name }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][company_name]" class="form-control">{{ shipment.receiver.company_name }}</span>
+                                {{ shipment.receiver.company_name }}
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][company_name]" id="input-inpostoc3-receiver-company-name-{{order_id}}-{{ shipment.id }}"
+                              value="{{ shipment.receiver.company_name }}" >
                               {% endif %}                              
                             </div>
                           </div>
-                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
+                          <div class="form-group row form-inline 
+                          {% if shipment.can_edit.sending_method_details %}
+                          required
+                          {% endif %}
+                          " style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-first-name-{{order_id}}-{{ shipment.id }}">{{ text_first_name }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -503,11 +561,18 @@
                               value="{{ shipment.receiver_id ? shipment.receiver.first_name : receiver.first_name }}"
                               placeholder="{{ text_first_name }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][first_name]" class="form-control">{{ shipment.receiver.first_name }}</span>
+                                {{ shipment.receiver.first_name }}
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][first_name]" id="input-inpostoc3-receiver-first-name-{{order_id}}-{{ shipment.id }}"
+                              value="{{ shipment.receiver.first_name }}" >
                               {% endif %}                              
                             </div>
                           </div>
-                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
+                          <div class="form-group row form-inline 
+                          {% if shipment.can_edit.sending_method_details %}
+                          required
+                          {% endif %}
+                          " style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-last-name-{{order_id}}-{{ shipment.id }}">{{ text_last_name }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -515,11 +580,18 @@
                               value="{{ shipment.receiver_id ? shipment.receiver.last_name : receiver.last_name }}"
                               placeholder="{{ text_last_name }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][last_name]" class="form-control">{{ shipment.receiver.last_name }}</span>
+                                {{ shipment.receiver.last_name }}
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][last_name]" id="input-inpostoc3-receiver-last-name-{{order_id}}-{{ shipment.id }}"
+                              value="{{ shipment.receiver.last_name }}" >
                               {% endif %}                                  
                             </div>
                           </div>
-                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
+                          <div class="form-group row form-inline 
+                          {% if shipment.can_edit.sending_method_details %}
+                          required
+                          {% endif %}
+                          " style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-phone-{{order_id}}-{{ shipment.id }}">{{ text_phone }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -527,11 +599,18 @@
                               value="{{ shipment.receiver_id ? shipment.receiver.phone : receiver.phone }}"
                               placeholder="{{ text_phone }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][phone]" class="form-control">{{ shipment.receiver.phone }}</span>
+                                {{ shipment.receiver.phone }}
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][phone]" id="input-inpostoc3-receiver-phone-{{order_id}}-{{ shipment.id }}"
+                              value="{{ shipment.receiver.phone }}" >
                               {% endif %}                         
                             </div>
                           </div>
-                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
+                          <div class="form-group row form-inline
+                          {% if shipment.can_edit.sending_method_details %} 
+                          required
+                          {% endif %}
+                          " style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-email-{{order_id}}-{{ shipment.id }}">{{ text_email }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -539,12 +618,15 @@
                               value="{{ shipment.receiver_id ? shipment.receiver.email : receiver.email }}"
                               placeholder="{{ text_email }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][email]" class="form-control">{{ shipment.receiver.email }}</span>
+                                {{ shipment.receiver.email }}
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][email]" id="input-inpostoc3-receiver-email-{{order_id}}-{{ shipment.id }}"
+                              value="{{ shipment.receiver.email }}" >
                               {% endif %}                              
                             </div>                            
                           </div>
                           <div class="form-group row form-inline
-                          {% if (shipment.receiver.street or shipment.receiver.building_number) %}
+                          {% if (shipment.receiver.street or shipment.receiver.building_number) and shipment.can_edit.sending_method_details %}
                           required 
                           {% endif %}
                           " style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;" id="input-inpostoc3-receiver-addr_street_row-{{order_id}}-{{ shipment.id }}">
@@ -559,12 +641,15 @@
                               value="{{ shipment.receiver_id ? shipment.receiver.street : receiver.street }}"
                               placeholder="{{ text_addr_street }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][street]" class="form-control">{{ shipment.receiver.street }}</span>
+                                {{ shipment.receiver.street }}
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][street]" id="input-inpostoc3-receiver-addr-street-{{order_id}}-{{ shipment.id }}" 
+                              value="{{ shipment.receiver.street }}" >
                               {% endif %}                              
                             </div>
                           </div>
                           <div class="form-group row form-inline
-                          {% if (shipment.receiver.street or shipment.receiver.building_number) %}
+                          {% if (shipment.receiver.street or shipment.receiver.building_number) and shipment.can_edit.sending_method_details %}
                           required 
                           {% endif %}
                           " style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;" id="input-inpostoc3-receiver-addr_building_number_row-{{order_id}}-{{ shipment.id }}">
@@ -579,12 +664,15 @@
                               value="{{ shipment.receiver_id ? shipment.receiver.building_number : receiver.building_number }}" 
                               placeholder="{{ text_addr_building_number }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][building_number]" class="form-control">{{ shipment.receiver.building_number }}</span>
+                              {{ shipment.receiver.building_number }}
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][building_number]" id="input-inpostoc3-receiver-addr-building_number-{{order_id}}-{{ shipment.id }}" 
+                              value="{{ shipment.receiver.building_number }}" >
                               {% endif %}                                
                             </div>
                           </div>
                           <div class="form-group row form-inline
-                          {% if not (shipment.receiver.street or shipment.receiver.building_number) and shipment.receiver.line1 %}
+                          {% if not (shipment.receiver.street or shipment.receiver.building_number) and shipment.receiver.line1 and shipment.can_edit.sending_method_details %}
                           required 
                           {% endif %}
                           " style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;" id="input-inpostoc3-receiver-addr_line_1_row-{{order_id}}-{{ shipment.id }}">
@@ -598,12 +686,15 @@
                               value="{{ shipment.receiver_id ? shipment.receiver.line1 : receiver.line1 }}" 
                               placeholder="{{ text_addr_line_1 }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][line1]" class="form-control">{{ shipment.receiver.line1 }}</span>
+                              {{ shipment.receiver.line1 }}
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][line1]" id="input-inpostoc3-receiver-addr-line-1-{{order_id}}-{{ shipment.id }}"
+                              value="{{ shipment.receiver.line1 }}" >
                               {% endif %}                                
                             </div>
                           </div>
                           <div class="form-group row form-inline
-                          {% if not (shipment.receiver.street or shipment.receiver.building_number) and shipment.receiver.line2 %}
+                          {% if not (shipment.receiver.street or shipment.receiver.building_number) and shipment.receiver.line2 and shipment.can_edit.sending_method_details %}
                           required 
                           {% endif %}
                           " style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;" id="input-inpostoc3-receiver-addr_line_2_row-{{order_id}}-{{ shipment.id }}">
@@ -617,11 +708,18 @@
                               value="{{ shipment.receiver_id ? shipment.receiver.line2 : receiver.line2 }}" 
                               placeholder="{{ text_addr_line_2 }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][line2]" class="form-control">{{ shipment.receiver.line2 }}</span>
+                              {{ shipment.receiver.line2 }}
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][line2]" id="input-inpostoc3-receiver-addr-line-2-{{order_id}}-{{ shipment.id }}"
+                              value="{{ shipment.receiver.line2 }}" >
                               {% endif %}                                
                             </div>
                           </div>
-                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
+                          <div class="form-group row form-inline 
+                          {% if shipment.can_edit.sending_method_details %}
+                          required
+                          {% endif %}
+                          " style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-addr-city-{{order_id}}-{{ shipment.id }}">{{ text_addr_city }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -629,11 +727,14 @@
                               value="{{ shipment.receiver_id ? shipment.receiver.city :  receiver.city }}" 
                               placeholder="{{ text_addr_city }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][city]" class="form-control">{{ shipment.receiver.city }}</span>
+                              {{ shipment.receiver.city }}
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][city]" id="input-inpostoc3-receiver-addr-city-{{order_id}}-{{ shipment.id }}"
+                              value="{{ shipment.receiver.city }}" >
                               {% endif %}                               
                             </div>
                           </div>
-                          <div class="form-group row form-inline {{ sender_country_postcode_required ? 'required' : '' }}" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
+                          <div class="form-group row form-inline {{ (sender_country_postcode_required and shipment.can_edit.sending_method_details) ? 'required' : '' }}" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-addr-post-code-{{order_id}}-{{ shipment.id }}">{{ text_addr_post_code }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -642,17 +743,20 @@
                               {{ sender_country_postcode_required ? 'required ' : '' }}
                               placeholder="{{ text_addr_post_code }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][post_code]" class="form-control">{{ shipment.receiver.post_code }}</span>
+                              {{ shipment.receiver.post_code }}
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][post_code]" id="input-inpostoc3-receiver-addr-post-code-{{order_id}}-{{ shipment.id }}"
+                              value="{{ shipment.receiver.post_code }}" >
                               {% endif %}                             
                             </div>
                           </div>
                           <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-addr-country-code-{{order_id}}-{{ shipment.id }}">{{ text_addr_country_code }}</label>
                             <div class="col-md-9">
-                              <span id="input-inpostoc3-receiver-addr-country-code-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.receiver.country_iso_code_2 }}</span>
+                              {{ shipment.receiver.country_iso_code_2 }}
                               <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
                               name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][country_iso_code_2]" id="input-inpostoc3-receiver-addr-country_iso_code_2-{{order_id}}-{{ shipment.id }}"
-                              value="{{ shipment.sender.country_iso_code_2 }}" >                             
+                              value="{{ shipment.receiver.country_iso_code_2 }}" >                             
                             </div>
                           </div>
                         </td>
@@ -727,22 +831,22 @@
                         <td class="text-left">
                           <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <div class="col-md-12">
-                              <span class="form-control" style="width: 100%;"
-                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][parcels][{{ parcel.id }}][number]" 
-                              id="input-inpostoc3-parcel-{{parcel.id}}-number-{{order_id}}-{{ shipment.id }}" >
                                 {{ parcel.number ?: text_none }}
-                              </span>
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][parcels][{{ parcel.id }}][number]" 
+                              id="input-inpostoc3-parcel-{{parcel.id}}-number-{{order_id}}-{{ shipment.id }}" 
+                              value="{{ parcel.number ?: null }}" >
                             </div>
                           </div>
                         </td>
                         <td class="text-left">
                           <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <div class="col-md-12">
-                              <span class="form-control" style="width: 100%;"
-                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][parcels][{{ parcel.id }}][tracking_number]" 
-                              id="input-inpostoc3-parcel-{{parcel.id}}-tracking_number-{{order_id}}-{{ shipment.id }}" >
                                 {{ parcel.tracking_number ?: text_none }}
-                              </span>
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][parcels][{{ parcel.id }}][tracking_number]" 
+                              id="input-inpostoc3-parcel-{{parcel.id}}-tracking_number-{{order_id}}-{{ shipment.id }}" 
+                              value="{{ parcel.tracking_number ?: null }}" >
                             </div>
                           </div>
                         </td>
@@ -777,7 +881,6 @@
               </tr>
             </tbody>
           </table>
-
         </div>
         <!-- add ability to add another shipment to order in future, for orders split to a couple of shipments and shipment not registered yet via API-->
         {% endfor %}

--- a/upload/admin/view/template/extension/shipping/inpostoc3_order_shipping.twig
+++ b/upload/admin/view/template/extension/shipping/inpostoc3_order_shipping.twig
@@ -63,80 +63,62 @@
                   
                   <table class="table table-condensed" style="width:33%; float: left;" id="shipment-{{ order_id }}">
                     <thead>
-                      <tr><td colspan="2">{{ text_sending_method_details }}</td></tr>
+                      <tr><td>{{ text_sending_method_details }}</td></tr>
                     </thead>
                     <tbody>
                       <tr>
-                        <td class="text-left col-md-4">{{ text_service }}:</td>
-                        <td class="text-left">
-                          {% if shipment.can_edit.sending_method_details %}
-                          <select form="form-inpostoc3-order-shipping-{{ order_id }}" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}" style="
-                          width: 100%;">
-                            <option value="0"
-                            {% if not shipment.service_id or shipment.service_id == 0 %}
-                            selected="selected"
-                            {% endif %}
-                            >{{ text_none }}</option>
-                            {% for service in inpost_services %}
-                            <option value="{{ service.id }}" 
-                              {% if shipment.service_id is same as (service.id) %}
+                        <td>
+                        <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                          <label class="col-md-2 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}">{{ text_service }}</label>
+                          <div class="col-md-10">
+                            {% if shipment.can_edit.sending_method_details %}
+                            <select form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}" class="form-control" style="width: 100%;">
+                              <option value="0"
+                              {% if not shipment.service_id or shipment.service_id == 0 %}
                               selected="selected"
                               {% endif %}
-                            >{{ attribute(_context,'text_' ~service.service_identifier~'_name') }}</option>
-                            {% endfor %}              
-                          </select>
-                          {% else %}
-                          {{ attribute(_context,'text_' ~service.service_identifier~'_name')  }}
-                          {% endif %}
-                        </td>
-                      </tr>
-                      <tr>
-                        <td class="text-left col-md-4">{{ text_sending_method }}:</td>
-                        <td class="text-left">
-                          {% if shipment.can_edit.sending_method_details %}
-                          <select form="form-inpostoc3-order-shipping-{{ order_id }}" id="input-inpostoc3-sending-method-{{order_id}}-{{ shipment.id }}" style="
-                          width: 100%;">
-                            <option value="0"
-                            {% if not shipment.custom_attributes.sending_method %}
-                            selected="selected"
+                              >{{ text_none }}</option>
+                              {% for service in inpost_services %}
+                              <option value="{{ service.id }}" 
+                                {% if shipment.service_id is same as (service.id) %}
+                                selected="selected"
+                                {% endif %}
+                              >{{ attribute(_context,'text_' ~service.service_identifier~'_name') }}</option>
+                              {% endfor %}              
+                            </select>
+                            {% else %}
+                            {{ attribute(_context,'text_' ~shipment.service_identifier~'_name')  }}
                             {% endif %}
-                            >{{ text_none }}</option>
-                            {% for service in inpost_services %}
-                            {% if service.id == shipment.service_id %}
-                            {% for sending_method in service.sending_methods %}
-                            <option value="{{ sending_method.sending_method_id }}" 
-                            {% if shipment.custom_attributes.sending_method is same as (sending_method.sending_method_identifier) %}
-                            selected="selected"
+                          </div>
+                        </div>
+                        <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                          <label class="col-md-2 control-label" for="input-inpostoc3-sending-method-{{order_id}}-{{ shipment.id }}">{{ text_sending_method }}</label>
+                          <div class="col-md-10">
+                            {% if shipment.can_edit.sending_method_details %}
+                            <select form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-sending-method-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-sending-method-{{order_id}}-{{ shipment.id }}" class="form-control" style="width: 100%;">
+                              <option value="0"
+                              {% if not shipment.custom_attributes.sending_method %}
+                              selected="selected"
+                              {% endif %}
+                              >{{ text_none }}</option>
+                              {% for service in inpost_services %}
+                              {% if service.id == shipment.service_id %}
+                              {% for sending_method in service.sending_methods %}
+                              <option value="{{ sending_method.sending_method_id }}" 
+                              {% if shipment.custom_attributes.sending_method is same as (sending_method.sending_method_identifier) %}
+                              selected="selected"
+                              {% endif %}
+                              >{{ attribute(_context,'text_sending_method_' ~sending_method.sending_method_identifier) }}</option>
+                              {% endfor %}
+                              {% endif %}
+                              {% endfor %}
+                              <!-- after initial fill do the java script stuff here to fill sending methods according to selected service -->              
+                            </select>
+                            {% else %}
+                            {{ attribute(_context,'text_' ~shipment.custom_attributes.sending_method~'_name')  }}
                             {% endif %}
-                            >{{ attribute(_context,'text_sending_method_' ~sending_method.sending_method_identifier) }}</option>
-                            {% endfor %}
-                            {% endif %}
-                            {% endfor %}
-                            <!-- after initial fill do the java script stuff here to fill sending methods according to selected service -->              
-                          </select>
-                          {% else %}
-                          {{ attribute(_context,'text_' ~service.service_identifier~'_name')  }}
-                          {% endif %}
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
-
-                  <table class="table table-condensed" style="width:33%; float: left;" id="shipment-{{ order_id }}">
-                    <thead>
-                      <tr><td colspan="2">{{ text_send_from }}</td></tr>
-                    </thead>
-                    <tbody>
-                      <tr>
-                        <td class="text-left">{{ text_service }}:</td>
-                        <td class="text-left">
-                          {% if inpostoc3_can_edit.service_method_details %}
-                          <select form="form-inpostoc3-order-shipping-{{ order_id }}" id="input-inpostoc3-service-{{order_id}}">
-                            
-              
-                          </select>
-                          {% else %}
-                          {% endif %}
+                          </div>
+                        </div>
                         </td>
                       </tr>
                     </tbody>
@@ -144,18 +126,312 @@
 
                   <table class="table table-condensed" style="width:33%; float: left;" id="shipment-{{ order_id }}">
                     <thead>
-                      <tr><td colspan="2">{{ text_send_to }}</td></tr>
+                      <tr><td>{{ text_send_from }}</td></tr>
                     </thead>
                     <tbody>
                       <tr>
-                        <td class="text-left">{{ text_service }}:</td>
                         <td class="text-left">
-                          {% if inpostoc3_can_edit.service_method_details %}
-                          <select form="form-inpostoc3-order-shipping-{{ order_id }}" id="input-inpostoc3-service-{{order_id}}">
-              
-                          </select>
-                          {% else %}
-                          {% endif %}
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;" id="{{ order_id }}-{{ shipment.id }}-dropoff-point">
+                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-selected-point">{{ text_selected_sending_point }}</label>
+                            <div class="col-md-9">
+                              {% if shipment.can_edit.sending_method_details %}
+                              <input type="button" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-selected-point" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-selected-point" 
+                              value=
+                              {% if shipment.custom_attributes.dropoff_point is empty %}
+                              "{{ text_click_to_select }}" 
+                              {% else %}
+                              "{{ shipment.custom_attributes.dropoff_point }}" 
+                              {% endif %}
+                              class="btn btn-primary form-control" style="width: 100%;" />
+                              {% else %}
+                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-selected-point" class="form-control">{{ shipment.custom_attributes.dropoff_point }}</span>
+                              {% endif %}                              
+                            </div>
+                          </div>
+
+                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-name">{{ text_name }}</label>
+                            <div class="col-md-9">
+                              {% if shipment.can_edit.sending_method_details %}
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-name" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-name" value="{{ sender.name }}" placeholder="{{ text_name }}"  class="form-control" style="width: 100%;" />
+                              {% else %}
+                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-name" class="form-control">{{ shipment.sender.name }}</span>
+                              {% endif %}     
+                            </div>
+                          </div>
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-company-name">{{ text_company_name }}</label>
+                            <div class="col-md-9">
+                              {% if shipment.can_edit.sending_method_details %}
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-company-name" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-company-name" value="{{ sender.company_name }}" placeholder="{{ text_company_name }}"  class="form-control" style="width: 100%;" />
+                              {% else %}
+                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-company-name" class="form-control">{{ shipment.sender.company_name }}</span>
+                              {% endif %}                              
+                            </div>
+                          </div>
+                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-first-name">{{ text_first_name }}</label>
+                            <div class="col-md-9">
+                              {% if shipment.can_edit.sending_method_details %}
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-first-name" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-first-name" value="{{ sender.first_name }}" placeholder="{{ text_first_name }}"  class="form-control" style="width: 100%;" />
+                              {% else %}
+                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-first-name" class="form-control">{{ shipment.sender.first_name }}</span>
+                              {% endif %}                              
+                            </div>
+                          </div>
+                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-last-name">{{ text_last_name }}</label>
+                            <div class="col-md-9">
+                              {% if shipment.can_edit.sending_method_details %}
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-last-name" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-last-name" value="{{ sender.last_name }}" placeholder="{{ text_last_name }}"  class="form-control" style="width: 100%;" />
+                              {% else %}
+                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-last-name" class="form-control">{{ shipment.sender.last_name }}</span>
+                              {% endif %}                                  
+                            </div>
+                          </div>
+                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-phone">{{ text_phone }}</label>
+                            <div class="col-md-9">
+                              {% if shipment.can_edit.sending_method_details %}
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-phone" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-phone" value="{{ sender.phone }}" placeholder="{{ text_phone }}"  class="form-control" style="width: 100%;" />
+                              {% else %}
+                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-phone" class="form-control">{{ shipment.sender.phone }}</span>
+                              {% endif %}                         
+                            </div>
+                          </div>
+                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-email">{{ text_email }}</label>
+                            <div class="col-md-9">
+                              {% if shipment.can_edit.sending_method_details %}
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-email" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-email" value="{{ sender.email }}" placeholder="{{ text_email }}"  class="form-control" style="width: 100%;" />
+                              {% else %}
+                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-email" class="form-control">{{ shipment.sender.email }}</span>
+                              {% endif %}                              
+                            </div>                            
+                          </div>
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-street">{{ text_addr_street }}</label>
+                            <div class="col-md-9">
+                              {% if shipment.can_edit.sending_method_details %}
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-street" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-street" value="{{ sender.street }}" placeholder="{{ text_addr_street }}"  class="form-control" style="width: 100%;" />
+                              {% else %}
+                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-street" class="form-control">{{ shipment.sender.street }}</span>
+                              {% endif %}                              
+                            </div>
+                          </div>
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-building-number">{{ text_addr_building_number }}</label>
+                            <div class="col-md-9">
+                              {% if shipment.can_edit.sending_method_details %}
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-building-number" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-building-number" value="{{ sender.building_number }}" placeholder="{{ text_addr_building_number }}"  class="form-control" style="width: 100%;" />
+                              {% else %}
+                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-building-number" class="form-control">{{ shipment.sender.building_number }}</span>
+                              {% endif %}                                
+                            </div>
+                          </div>
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-line-1">{{ text_addr_line_1 }}</label>
+                            <div class="col-md-9">
+                              {% if shipment.can_edit.sending_method_details %}
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-line-1" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-line-1" value="{{ sender.line1 }}" placeholder="{{ text_addr_line_1 }}"  class="form-control" style="width: 100%;" />
+                              {% else %}
+                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-line-1" class="form-control">{{ shipment.sender.line1 }}</span>
+                              {% endif %}                                
+                            </div>
+                          </div>
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-line-2">{{ text_addr_line_2 }}</label>
+                            <div class="col-md-9">
+                              {% if shipment.can_edit.sending_method_details %}
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-line-2" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-line-2" value="{{ sender.line2 }}" placeholder="{{ text_addr_line_2 }}"  class="form-control" style="width: 100%;" />
+                              {% else %}
+                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-line-2" class="form-control">{{ shipment.sender.line2 }}</span>
+                              {% endif %}                                
+                            </div>
+                          </div>
+                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-city">{{ text_addr_city }}</label>
+                            <div class="col-md-9">
+                              {% if shipment.can_edit.sending_method_details %}
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-city" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-city" value="{{ sender.city }}" placeholder="{{ text_addr_city }}"  class="form-control" style="width: 100%;" />
+                              {% else %}
+                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-city" class="form-control">{{ shipment.sender.city }}</span>
+                              {% endif %}                               
+                            </div>
+                          </div>
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-post-code">{{ text_addr_post_code }}</label>
+                            <div class="col-md-9">
+                              {% if shipment.can_edit.sending_method_details %}
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-post-code" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-post-code" value="{{ sender.post_code }}" placeholder="{{ text_addr_post_code }}"  class="form-control" style="width: 100%;" />
+                              {% else %}
+                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-post-code" class="form-control">{{ shipment.sender.post_code }}</span>
+                              {% endif %}                             
+                            </div>
+                          </div>
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-country-code">{{ text_addr_country_code }}</label>
+                            <div class="col-md-9">
+                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-sender-addr-country-code" class="form-control">{{ shipment.sender.country_iso_code_2 }}</span>                             
+                            </div>
+                          </div>
+                        </td>
+
+                      </tr>
+                    </tbody>
+                  </table>
+
+                  <table class="table table-condensed" style="width:33%; float: left;" id="shipment-{{ order_id }}">
+                    <thead>
+                      <tr><td>{{ text_send_to }}</td></tr>
+                    </thead>
+                    <tbody>
+                      <tr>
+                        <td class="text-left">
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;" id="{{ order_id }}-{{ shipment.id }}-target-point">
+                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-selected-point">{{ text_selected_target_point }}</label>
+                            <div class="col-md-9">
+                              {% if shipment.can_edit.sending_method_details %}
+                              <input type="button" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-selected-point" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-selected-point" 
+                              value=
+                              {% if shipment.custom_attributes.target_point is empty %}
+                              "{{ text_click_to_select }}" 
+                              {% else %}
+                              "{{ shipment.custom_attributes.target_point }}" 
+                              {% endif %}
+                              class="btn btn-primary form-control" style="width: 100%;" />
+                              {% else %}
+                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-selected-point" class="form-control">{{ shipment.custom_attributes.target_point }}</span>
+                              {% endif %}                              
+                            </div>
+                          </div>
+
+                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-name">{{ text_name }}</label>
+                            <div class="col-md-9">
+                              {% if shipment.can_edit.sending_method_details %}
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-name" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-name" value="{{ receiver.name }}" placeholder="{{ text_name }}"  class="form-control" style="width: 100%;" />
+                              {% else %}
+                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-name" class="form-control">{{ shipment.receiver.name }}</span>
+                              {% endif %}     
+                            </div>
+                          </div>
+                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-company-name">{{ text_company_name }}</label>
+                            <div class="col-md-9">
+                              {% if shipment.can_edit.sending_method_details %}
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-company-name" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-company-name" value="{{ receiver.company_name }}" placeholder="{{ text_company_name }}"  class="form-control" style="width: 100%;" />
+                              {% else %}
+                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-company-name" class="form-control">{{ shipment.receiver.company_name }}</span>
+                              {% endif %}                              
+                            </div>
+                          </div>
+                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-first-name">{{ text_first_name }}</label>
+                            <div class="col-md-9">
+                              {% if shipment.can_edit.sending_method_details %}
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-first-name" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-first-name" value="{{ receiver.first_name }}" placeholder="{{ text_first_name }}"  class="form-control" style="width: 100%;" />
+                              {% else %}
+                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-first-name" class="form-control">{{ shipment.receiver.first_name }}</span>
+                              {% endif %}                              
+                            </div>
+                          </div>
+                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-last-name">{{ text_last_name }}</label>
+                            <div class="col-md-9">
+                              {% if shipment.can_edit.sending_method_details %}
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-last-name" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-last-name" value="{{ receiver.last_name }}" placeholder="{{ text_last_name }}"  class="form-control" style="width: 100%;" />
+                              {% else %}
+                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-last-name" class="form-control">{{ shipment.receiver.last_name }}</span>
+                              {% endif %}                                  
+                            </div>
+                          </div>
+                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-phone">{{ text_phone }}</label>
+                            <div class="col-md-9">
+                              {% if shipment.can_edit.sending_method_details %}
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-phone" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-phone" value="{{ receiver.phone }}" placeholder="{{ text_phone }}"  class="form-control" style="width: 100%;" />
+                              {% else %}
+                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-phone" class="form-control">{{ shipment.receiver.phone }}</span>
+                              {% endif %}                         
+                            </div>
+                          </div>
+                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-email">{{ text_email }}</label>
+                            <div class="col-md-9">
+                              {% if shipment.can_edit.sending_method_details %}
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-email" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-email" value="{{ receiver.email }}" placeholder="{{ text_email }}"  class="form-control" style="width: 100%;" />
+                              {% else %}
+                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-email" class="form-control">{{ shipment.receiver.email }}</span>
+                              {% endif %}                              
+                            </div>                            
+                          </div>
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-street">{{ text_addr_street }}</label>
+                            <div class="col-md-9">
+                              {% if shipment.can_edit.sending_method_details %}
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-street" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-street" value="{{ receiver.street }}" placeholder="{{ text_addr_street }}"  class="form-control" style="width: 100%;" />
+                              {% else %}
+                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-street" class="form-control">{{ shipment.receiver.street }}</span>
+                              {% endif %}                              
+                            </div>
+                          </div>
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-building-number">{{ text_addr_building_number }}</label>
+                            <div class="col-md-9">
+                              {% if shipment.can_edit.sending_method_details %}
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-building-number" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-building-number" value="{{ receiver.building_number }}" placeholder="{{ text_addr_building_number }}"  class="form-control" style="width: 100%;" />
+                              {% else %}
+                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-building-number" class="form-control">{{ shipment.receiver.building_number }}</span>
+                              {% endif %}                                
+                            </div>
+                          </div>
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-line-1">{{ text_addr_line_1 }}</label>
+                            <div class="col-md-9">
+                              {% if shipment.can_edit.sending_method_details %}
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-line-1" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-line-1" value="{{ receiver.line1 }}" placeholder="{{ text_addr_line_1 }}"  class="form-control" style="width: 100%;" />
+                              {% else %}
+                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-line-1" class="form-control">{{ shipment.receiver.line1 }}</span>
+                              {% endif %}                                
+                            </div>
+                          </div>
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-line-2">{{ text_addr_line_2 }}</label>
+                            <div class="col-md-9">
+                              {% if shipment.can_edit.sending_method_details %}
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-line-2" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-line-2" value="{{ receiver.line2 }}" placeholder="{{ text_addr_line_2 }}"  class="form-control" style="width: 100%;" />
+                              {% else %}
+                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-line-2" class="form-control">{{ shipment.receiver.line2 }}</span>
+                              {% endif %}                                
+                            </div>
+                          </div>
+                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-city">{{ text_addr_city }}</label>
+                            <div class="col-md-9">
+                              {% if shipment.can_edit.sending_method_details %}
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-city" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-city" value="{{ receiver.city }}" placeholder="{{ text_addr_city }}"  class="form-control" style="width: 100%;" />
+                              {% else %}
+                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-city" class="form-control">{{ shipment.receiver.city }}</span>
+                              {% endif %}                               
+                            </div>
+                          </div>
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-post-code">{{ text_addr_post_code }}</label>
+                            <div class="col-md-9">
+                              {% if shipment.can_edit.sending_method_details %}
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-post-code" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-post-code" value="{{ receiver.post_code }}" placeholder="{{ text_addr_post_code }}"  class="form-control" style="width: 100%;" />
+                              {% else %}
+                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-post-code" class="form-control">{{ shipment.receiver.post_code }}</span>
+                              {% endif %}                             
+                            </div>
+                          </div>
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                            <label class="col-md-3 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-country-code">{{ text_addr_country_code }}</label>
+                            <div class="col-md-9">
+                              <span name="inpostoc3-service-{{order_id}}-{{ shipment.id }}-receiver-addr-country-code" class="form-control">{{ shipment.receiver.country_iso_code_2 }}</span>                             
+                            </div>
+                          </div>
                         </td>
                       </tr>
                     </tbody>

--- a/upload/admin/view/template/extension/shipping/inpostoc3_order_shipping.twig
+++ b/upload/admin/view/template/extension/shipping/inpostoc3_order_shipping.twig
@@ -589,6 +589,7 @@
                         <td class="text-left">
                           <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <div class="col-md-12">
+                              {% if shipment.can_edit.sending_method_details %}
                               <select form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][parcels][{{ parcel.id }}][template_id]" id="input-inpostoc3-parcel-{{ parcel.id }}-template-id-{{order_id}}-{{ shipment.id }}" class="form-control" style="width: 100%;">
                               <option value="0"
                               {% if not parcel.id %}
@@ -604,6 +605,18 @@
                               >{{ parcel_template.template_identifier }} - {{ parcel_template.max_height}}mm x {{ parcel_template.max_width}}mm x {{ parcel_template.max_length}}mm x {{ parcel_template.max_weight}}kg </option>
                               {% endfor %}
                               </select>
+                              {% else %}
+                              {% for parcel_template in parcel_templates %}
+                              {% if parcel.template_id is same as (parcel_template.id) %}
+                              <span class="form-control"
+                                name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][parcels][{{ parcel.id }}][template_id]" 
+                                id="input-inpostoc3-parcel-{{ parcel.id }}-template-id-{{order_id}}-{{ shipment.id }}"
+                              >
+                                {{ parcel_template.template_identifier }} - {{ parcel_template.max_height}}mm x {{ parcel_template.max_width}}mm x {{ parcel_template.max_length}}mm x {{ parcel_template.max_weight}}kg
+                              </span>
+                              {% endif %}
+                              {% endfor %}
+                              {% endif %}
                               <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
                               name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][parcels][{{ parcel.id }}][id]" id="input-inpostoc3-parcel-{{parcel.id}}-id-{{order_id}}-{{ shipment.id }}"
                               value="{{ parcel.id }}" >
@@ -613,11 +626,27 @@
                             </div>
                           </div>
                         </td>
-                        <td class="text-left">{{ text_parcel_number }}
-
+                        <td class="text-left">
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
+                            <div class="col-md-12">
+                              <span class="form-control" style="width: 100%;"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][parcels][{{ parcel.id }}][number]" 
+                              id="input-inpostoc3-parcel-{{parcel.id}}-number-{{order_id}}-{{ shipment.id }}" >
+                                {{ parcel.number ?: text_none }}
+                              </span>
+                            </div>
+                          </div>
                         </td>
-                        <td class="text-left">{{ text_parcel_tracking_number }}
-
+                        <td class="text-left">
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
+                            <div class="col-md-12">
+                              <span class="form-control" style="width: 100%;"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][parcels][{{ parcel.id }}][tracking_number]" 
+                              id="input-inpostoc3-parcel-{{parcel.id}}-tracking_number-{{order_id}}-{{ shipment.id }}" >
+                                {{ parcel.tracking_number ?: text_none }}
+                              </span>
+                            </div>
+                          </div>
                         </td>
                         <td></td>
                       </tr>
@@ -630,12 +659,12 @@
               <tr>
                 <td colspan="2" class="text-center">
                   <div class="pull-center">
+                    {% if shipment.status is same as('draft') %}
                     <button type="submit" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" data-toggle="tooltip" title="{{ button_shipping_save }}" class="btn btn-primary" formaction="{{ action_save }}" data-original-title="Save"><i class="fa fa-save"></i></button> 
+                    {% endif %}
                     <button type="submit" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" data-toggle="tooltip" title="{{ button_shipping_print }}" class="btn btn-primary" formaction=""><i class="fa fa-truck"></i></button>
-                    {% if shipment.can_edit.sending_method_details %}
                     <form method="post" enctype="multipart/form-data" id="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" class="col-md-12">
                     </form>
-                    {% endif %}
                   </div>
                 </td>
               </tr>

--- a/upload/admin/view/template/extension/shipping/inpostoc3_order_shipping.twig
+++ b/upload/admin/view/template/extension/shipping/inpostoc3_order_shipping.twig
@@ -68,7 +68,7 @@
                     <tbody>
                       <tr>
                         <td>
-                        <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                        <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                           <label class="col-md-2 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}">{{ text_service }}</label>
                           <div class="col-md-10">
                             {% if shipment.can_edit.sending_method_details %}
@@ -91,7 +91,7 @@
                             {% endif %}
                           </div>
                         </div>
-                        <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                        <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                           <label class="col-md-2 control-label" for="input-inpostoc3-sending-method-{{order_id}}-{{ shipment.id }}">{{ text_sending_method }}</label>
                           <div class="col-md-10">
                             {% if shipment.can_edit.sending_method_details %}
@@ -131,7 +131,7 @@
                     <tbody>
                       <tr>
                         <td class="text-left">
-                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;" id="{{ order_id }}-{{ shipment.id }}-dropoff-point">
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;" id="{{ order_id }}-{{ shipment.id }}-dropoff-point">
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-selected-point-{{order_id}}-{{ shipment.id }}">{{ text_selected_sending_point }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -142,7 +142,7 @@
                               {% else %}
                               "{{ shipment.custom_attributes.dropoff_point }}" 
                               {% endif %}
-                              {% if shipment.custom_attributes.sending_method is not same as("parcel_locker") %}
+                              {% if shipment.custom_attributes.sending_method is not same as ("parcel_locker") %}
                               disabled 
                               {% endif %}
                               class="btn btn-primary form-control" style="width: 100%;" />
@@ -153,7 +153,7 @@
                           </div>
 
                           {% if shipment.can_edit.sending_method_details %}
-                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <div class="col-md-12">
                               <select  name="input-inpostoc3-select-sender-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-select-sender-{{order_id}}-{{ shipment.id }}" class="form-control" style="width: 100%;">
                               <option value="0"
@@ -175,7 +175,7 @@
 						              {% endif %}
 
 
-                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-name-{{order_id}}-{{ shipment.id }}">{{ text_name }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -187,7 +187,7 @@
                               {% endif %}     
                             </div>
                           </div>
-                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-company-name-{{order_id}}-{{ shipment.id }}">{{ text_company_name }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -199,7 +199,7 @@
                               {% endif %}                              
                             </div>
                           </div>
-                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-first-name-{{order_id}}-{{ shipment.id }}">{{ text_first_name }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -211,7 +211,7 @@
                               {% endif %}                              
                             </div>
                           </div>
-                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-last-name-{{order_id}}-{{ shipment.id }}">{{ text_last_name }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -223,7 +223,7 @@
                               {% endif %}                                  
                             </div>
                           </div>
-                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-phone-{{order_id}}-{{ shipment.id }}">{{ text_phone }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -235,7 +235,7 @@
                               {% endif %}                         
                             </div>
                           </div>
-                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-email-{{order_id}}-{{ shipment.id }}">{{ text_email }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -247,7 +247,7 @@
                               {% endif %}                              
                             </div>                            
                           </div>
-                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-addr-street-{{order_id}}-{{ shipment.id }}">{{ text_addr_street }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -259,7 +259,7 @@
                               {% endif %}                              
                             </div>
                           </div>
-                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-addr-building-number-{{order_id}}-{{ shipment.id }}">{{ text_addr_building_number }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -271,7 +271,7 @@
                               {% endif %}                                
                             </div>
                           </div>
-                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-addr-line-1-{{order_id}}-{{ shipment.id }}">{{ text_addr_line_1 }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -283,7 +283,7 @@
                               {% endif %}                                
                             </div>
                           </div>
-                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-addr-line-2-{{order_id}}-{{ shipment.id }}">{{ text_addr_line_2 }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -295,7 +295,7 @@
                               {% endif %}                                
                             </div>
                           </div>
-                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-addr-city-{{order_id}}-{{ shipment.id }}">{{ text_addr_city }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -307,7 +307,7 @@
                               {% endif %}                               
                             </div>
                           </div>
-                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-addr-post-code-{{order_id}}-{{ shipment.id }}">{{ text_addr_post_code }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -319,7 +319,7 @@
                               {% endif %}                             
                             </div>
                           </div>
-                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-addr-country-code-{{order_id}}-{{ shipment.id }}">{{ text_addr_country_code }}</label>
                             <div class="col-md-9">
                               <span name="input-inpostoc3-sender-addr-country-code-{{order_id}}-{{ shipment.id }}" class="form-control" id="input-inpostoc3-sender-addr-country-code-{{order_id}}-{{ shipment.id }}">{{ shipment.sender.country_iso_code_2 }}</span>                             
@@ -338,25 +338,28 @@
                     <tbody>
                       <tr>
                         <td class="text-left">
-                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;" id="{{ order_id }}-{{ shipment.id }}-target-point">
-                            <label class="col-md-3 control-label" for="input-inpostoc3-{{order_id}}-{{ shipment.id }}-receiver-selected-point">{{ text_selected_target_point }}</label>
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;" id="{{ order_id }}-{{ shipment.id }}-target-point">
+                            <label class="col-md-3 control-label" for="input-inpostoc3-receiver-selected-point-{{order_id}}-{{ shipment.id }}">{{ text_selected_target_point }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="button" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3-{{order_id}}-{{ shipment.id }}-receiver-selected-point" id="input-inpostoc3-{{order_id}}-{{ shipment.id }}-receiver-selected-point" 
+                              <input type="button" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3-receiver-selected-point-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-receiver-selected-point-{{order_id}}-{{ shipment.id }}" 
                               value=
                               {% if shipment.custom_attributes.target_point is empty %}
                               "{{ text_click_to_select }}" 
                               {% else %}
                               "{{ shipment.custom_attributes.target_point }}" 
                               {% endif %}
+                              {% if shipment.service_id is not same as("1") %}
+                              disabled 
+                              {% endif %}
                               class="btn btn-primary form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3-{{order_id}}-{{ shipment.id }}-receiver-selected-point" class="form-control">{{ shipment.custom_attributes.target_point }}</span>
+                              <span name="input-inpostoc3-receiver-selected-point-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.custom_attributes.target_point }}</span>
                               {% endif %}                              
                             </div>
                           </div>
 
-                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-name-{{order_id}}-{{ shipment.id }}">{{ text_name }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -368,7 +371,7 @@
                               {% endif %}     
                             </div>
                           </div>
-                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-company-name-{{order_id}}-{{ shipment.id }}">{{ text_company_name }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -380,7 +383,7 @@
                               {% endif %}                              
                             </div>
                           </div>
-                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-first-name-{{order_id}}-{{ shipment.id }}">{{ text_first_name }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -392,7 +395,7 @@
                               {% endif %}                              
                             </div>
                           </div>
-                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-last-name-{{order_id}}-{{ shipment.id }}">{{ text_last_name }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -404,7 +407,7 @@
                               {% endif %}                                  
                             </div>
                           </div>
-                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-phone-{{order_id}}-{{ shipment.id }}">{{ text_phone }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -416,7 +419,7 @@
                               {% endif %}                         
                             </div>
                           </div>
-                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-email-{{order_id}}-{{ shipment.id }}">{{ text_email }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -428,7 +431,7 @@
                               {% endif %}                              
                             </div>                            
                           </div>
-                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-addr-street-{{order_id}}-{{ shipment.id }}">{{ text_addr_street }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -440,7 +443,7 @@
                               {% endif %}                              
                             </div>
                           </div>
-                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-addr-building-number-{{order_id}}-{{ shipment.id }}">{{ text_addr_building_number }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -452,7 +455,7 @@
                               {% endif %}                                
                             </div>
                           </div>
-                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-addr-line-1-{{order_id}}-{{ shipment.id }}">{{ text_addr_line_1 }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -464,7 +467,7 @@
                               {% endif %}                                
                             </div>
                           </div>
-                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-addr-line-2-{{order_id}}-{{ shipment.id }}">{{ text_addr_line_2 }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -476,7 +479,7 @@
                               {% endif %}                                
                             </div>
                           </div>
-                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-addr-city-{{order_id}}-{{ shipment.id }}">{{ text_addr_city }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -488,7 +491,7 @@
                               {% endif %}                               
                             </div>
                           </div>
-                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-addr-post-code-{{order_id}}-{{ shipment.id }}">{{ text_addr_post_code }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -500,7 +503,7 @@
                               {% endif %}                             
                             </div>
                           </div>
-                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-addr-country-code-{{order_id}}-{{ shipment.id }}">{{ text_addr_country_code }}</label>
                             <div class="col-md-9">
                               <span name="input-inpostoc3-receiver-addr-country-code-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.receiver.country_iso_code_2 }}</span>                             
@@ -535,7 +538,7 @@
                       {% for parcel in shipment.parcels %}
                       <tr>
                         <td class="text-left">
-                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 10px; padding-bottom: 10px;">
+                          <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <div class="col-md-12">
                               <select  name="input-inpostoc3-parcel-{{order_id}}-{{ shipment.id }}-{{ parcel.id }}" id="input-inpostoc3-parcel-{{order_id}}-{{ shipment.id }}-{{ parcel.id }}" class="form-control" style="width: 100%;">
                               <option value="0"

--- a/upload/admin/view/template/extension/shipping/inpostoc3_order_shipping.twig
+++ b/upload/admin/view/template/extension/shipping/inpostoc3_order_shipping.twig
@@ -3,10 +3,6 @@
   <div class="page-header">
     <div class="container-fluid">
       <div class="pull-right">
-        {% if inpostoc3_can_edit.shipment %}
-        <button type="submit" form="form-inpostoc3-order-shipping" data-toggle="tooltip" title="{{ button_save }}" class="btn btn-primary" formaction="{{ action_save }}"><i class="fa fa-save"></i></button>
-        {% endif %}
-        <!-- <button type="submit" form="form-inpostoc3-order-shipping" data-toggle="tooltip" title="{{ button_shipping_print }}" class="btn btn-primary" formaction="{{ action_dispatch }}"><i class="fa fa-truck"></i></button> -->
         <a href="{{ cancel }}" data-toggle="tooltip" title="{{ button_cancel }}" class="btn btn-default"><i class="fa fa-reply"></i></a>
       </div>
       <h1>{{ heading_title_order_shipping }}</h1>
@@ -18,16 +14,28 @@
     </div>
   </div>
   <div class="container-fluid">
+    <!--
+    <ol>
+      {% for key, value in _context  %}
+        <li>{{ key }} </li>
+      {% endfor %}
+  </ol>
+  -->
     {% if error_warning %}
     <div class="alert alert-danger alert-dismissible"><i class="fa fa-exclamation-circle"></i> {{ error_warning }}
       <button type="button" class="close" data-dismiss="alert">&times;</button>
     </div>
     {% endif %}
+    {% if success %}
+    <div class="alert alert-success alert-dismissible"><i class="fa fa-check-circle"></i> {{ success }}
+      <button type="button" class="close" data-dismiss="alert">&times;</button>
+    </div>
+    {% endif %}
     {% if shipping_code_inpostoc3_used %}
-    <div class="panel panel-default">
+    <!-- <div class="panel panel-default">
       <div class="panel-heading">
         <h3 class="panel-title"><i class="fa 
-        {% if inpostoc3_can_edit.shipment %}
+        {% if inpostoc3_can_edit_order %}
         fa-pencil
         {% else %}
         fa-info-circle
@@ -35,6 +43,7 @@
         "></i>Order (#{{ order_id }})</h3>
       </div>
     </div>
+     -->
 
     
     <!-- Shipments -->
@@ -66,13 +75,14 @@
                       <tr><td>{{ text_sending_method_details }}</td></tr>
                     </thead>
                     <tbody>
+                      {% set dropoff_enable = false %}
                       <tr>
                         <td>
                         <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                           <label class="col-md-2 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}">{{ text_service }}</label>
                           <div class="col-md-10">
                             {% if shipment.can_edit.sending_method_details %}
-                            <select form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}" class="form-control" style="width: 100%;">
+                            <select form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][service_id]" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}" class="form-control" style="width: 100%;">
                               <option value="0"
                               {% if not shipment.service_id or shipment.service_id == 0 %}
                               selected="selected"
@@ -89,13 +99,22 @@
                             {% else %}
                             {{ attribute(_context,'text_' ~shipment.service_identifier~'_name')  }}
                             {% endif %}
+                            <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][id]" id="input-inpostoc3-shipment-id-{{order_id}}-{{ shipment.id }}"
+                              value="{{ shipment.id }}" >
+                            <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][order_id]" id="input-inpostoc3-shipment-order_id-{{order_id}}-{{ shipment.id }}"
+                              value="{{ order_id }}" >
+                            <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][id]" id="input-inpostoc3-order-id-{{order_id}}-{{ shipment.id }}"
+                              value="{{ order_id }}" >
                           </div>
                         </div>
                         <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                           <label class="col-md-2 control-label" for="input-inpostoc3-sending-method-{{order_id}}-{{ shipment.id }}">{{ text_sending_method }}</label>
                           <div class="col-md-10">
                             {% if shipment.can_edit.sending_method_details %}
-                            <select form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-sending-method-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-sending-method-{{order_id}}-{{ shipment.id }}" class="form-control" style="width: 100%;">
+                            <select form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][custom_attributes][sending_method]" id="input-inpostoc3-sending-method-{{order_id}}-{{ shipment.id }}" class="form-control" style="width: 100%;">
                               <option value="0"
                               {% if not shipment.custom_attributes.sending_method %}
                               selected="selected"
@@ -105,8 +124,12 @@
                               {% if service.id == shipment.service_id %}
                               {% for sending_method in service.sending_methods %}
                               <option value="{{ sending_method.sending_method_id }}" 
-                              {% if shipment.custom_attributes.sending_method is same as (sending_method.sending_method_identifier) %}
+                              {% if shipment.custom_attributes.sending_method == sending_method.sending_method_id %}
                               selected="selected"
+                              
+                                {% if sending_method.sending_method_identifier is same as ("parcel_locker") %} 
+                                {% set dropoff_enable = true %}
+                                {% endif %}
                               {% endif %}
                               >{{ attribute(_context,'text_sending_method_' ~sending_method.sending_method_identifier) }}</option>
                               {% endfor %}
@@ -117,6 +140,14 @@
                             {% else %}
                             {{ attribute(_context,'text_' ~shipment.custom_attributes.sending_method~'_name')  }}
                             {% endif %}
+                            <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" 
+                            name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][custom_attributes][shipment_id]" id="input-inpostoc3-shipment-cattr-shipment_id-{{order_id}}-{{ shipment.id }}" 
+                              value="{{ shipment.id }}" >
+                            {% if shipment.custom_attributes.id %}
+                            <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" 
+                            name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][custom_attributes][id]" id="input-inpostoc3-shipment-cattr-{{ shipment.custom_attributes.id }}-id-{{order_id}}-{{ shipment.id }}" 
+                              value="{{ shipment.custom_attributes.id }}" >
+                              {% endif %}
                           </div>
                         </div>
                         </td>
@@ -135,19 +166,19 @@
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-selected-point-{{order_id}}-{{ shipment.id }}">{{ text_selected_sending_point }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="button" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3-sender-selected-point-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-sender-selected-point-{{order_id}}-{{ shipment.id }}" 
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][custom_attributes][dropoff_point]" id="input-inpostoc3-sender-selected-point-{{order_id}}-{{ shipment.id }}" 
                               value=
                               {% if shipment.custom_attributes.dropoff_point is empty %}
                               "{{ text_click_to_select }}" 
                               {% else %}
                               "{{ shipment.custom_attributes.dropoff_point }}" 
                               {% endif %}
-                              {% if shipment.custom_attributes.sending_method is not same as ("parcel_locker") %}
+                              {% if not dropoff_enable %}
                               disabled 
                               {% endif %}
                               class="btn btn-primary form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3-sender-selected-point-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.custom_attributes.dropoff_point }}</span>
+                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][custom_attributes][dropoff_point]" class="form-control">{{ shipment.custom_attributes.dropoff_point }}</span>
                               {% endif %}                              
                             </div>
                           </div>
@@ -179,23 +210,31 @@
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-name-{{order_id}}-{{ shipment.id }}">{{ text_name }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-sender-name-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-sender-name-{{order_id}}-{{ shipment.id }}" 
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][name]" id="input-inpostoc3-sender-name-{{order_id}}-{{ shipment.id }}" 
                               value="{{ shipment.sender_id ? shipment.sender.name : sender.name }}"
                               placeholder="{{ text_name }}"  class="form-control" style="width: 100%;" />
                               {% else %}
                               <span name="input-inpostoc3-{{order_id}}-{{ shipment.id }}-sender-name" class="form-control">{{ shipment.sender.name }}</span>
-                              {% endif %}     
+                              {% endif %}
+                              {% if shipment.sender_id %}
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][id]" id="input-inpostoc3-sender-id-{{order_id}}-{{ shipment.id }}"
+                              value="{{ shipment.sender_id }}" >
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender_id]" id="input-inpostoc3-sender_id-{{order_id}}-{{ shipment.id }}"
+                              value="{{ shipment.sender_id }}" >
+                              {% endif %}
                             </div>
                           </div>
                           <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-company-name-{{order_id}}-{{ shipment.id }}">{{ text_company_name }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3-sender-company-name-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-sender-company-name-{{order_id}}-{{ shipment.id }}" 
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][company_name]" id="input-inpostoc3-sender-company-name-{{order_id}}-{{ shipment.id }}" 
                               value="{{ shipment.sender_id ? shipment.sender.company_name : sender.company_name }}"
                               placeholder="{{ text_company_name }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3-sender-company-name-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.sender.company_name }}</span>
+                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][company_name]" class="form-control">{{ shipment.sender.company_name }}</span>
                               {% endif %}                              
                             </div>
                           </div>
@@ -203,11 +242,11 @@
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-first-name-{{order_id}}-{{ shipment.id }}">{{ text_first_name }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-sender-first-name-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-sender-first-name-{{order_id}}-{{ shipment.id }}" 
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][first_name]" id="input-inpostoc3-sender-first-name-{{order_id}}-{{ shipment.id }}" 
                               value="{{ shipment.sender_id ? shipment.sender.first_name : sender.first_name }}"
                               placeholder="{{ text_first_name }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3-sender-first-name-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.sender.first_name }}</span>
+                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][first_name]" class="form-control">{{ shipment.sender.first_name }}</span>
                               {% endif %}                              
                             </div>
                           </div>
@@ -215,11 +254,11 @@
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-last-name-{{order_id}}-{{ shipment.id }}">{{ text_last_name }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-sender-last-name-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-sender-last-name-{{order_id}}-{{ shipment.id }}" 
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][last_name]" id="input-inpostoc3-sender-last-name-{{order_id}}-{{ shipment.id }}" 
                               value="{{ shipment.sender_id ? shipment.sender.last_name : sender.last_name }}"  
                               placeholder="{{ text_last_name }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3-sender-last-name-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.sender.last_name }}</span>
+                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][last_name]" class="form-control">{{ shipment.sender.last_name }}</span>
                               {% endif %}                                  
                             </div>
                           </div>
@@ -227,11 +266,11 @@
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-phone-{{order_id}}-{{ shipment.id }}">{{ text_phone }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-sender-phone-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-sender-phone-{{order_id}}-{{ shipment.id }}" 
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][phone]" id="input-inpostoc3-sender-phone-{{order_id}}-{{ shipment.id }}" 
                               value="{{ shipment.sender_id ? shipment.sender.phone : sender.phone }}" 
                               placeholder="{{ text_phone }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3-sender-phone-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.sender.phone }}</span>
+                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][phone]" class="form-control">{{ shipment.sender.phone }}</span>
                               {% endif %}                         
                             </div>
                           </div>
@@ -239,11 +278,11 @@
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-email-{{order_id}}-{{ shipment.id }}">{{ text_email }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-sender-email-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-sender-email-{{order_id}}-{{ shipment.id }}" 
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][email]" id="input-inpostoc3-sender-email-{{order_id}}-{{ shipment.id }}" 
                               value="{{ shipment.sender_id ? shipment.sender.email : sender.email }}" 
                               placeholder="{{ text_email }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3-sender-email-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.sender.email }}</span>
+                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][email]" class="form-control">{{ shipment.sender.email }}</span>
                               {% endif %}                              
                             </div>                            
                           </div>
@@ -251,11 +290,11 @@
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-addr-street-{{order_id}}-{{ shipment.id }}">{{ text_addr_street }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-sender-addr-street-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-sender-addr-street-{{order_id}}-{{ shipment.id }}" 
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][street]" id="input-inpostoc3-sender-addr-street-{{order_id}}-{{ shipment.id }}" 
                               value="{{ shipment.sender_id ? shipment.sender.street : sender.street }}" 
                               placeholder="{{ text_addr_street }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3-sender-addr-street-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.sender.street }}</span>
+                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][street]" class="form-control">{{ shipment.sender.street }}</span>
                               {% endif %}                              
                             </div>
                           </div>
@@ -263,11 +302,11 @@
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-addr-building-number-{{order_id}}-{{ shipment.id }}">{{ text_addr_building_number }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-sender-addr-building-number-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-sender-addr-building-number-{{order_id}}-{{ shipment.id }}" 
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][building_number]" id="input-inpostoc3-sender-addr-building-number-{{order_id}}-{{ shipment.id }}" 
                               value="{{ shipment.sender_id ? shipment.sender.building_number : sender.building_number }}" 
                               placeholder="{{ text_addr_building_number }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3-sender-addr-building-number-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.sender.building_number }}</span>
+                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][building_number]" class="form-control">{{ shipment.sender.building_number }}</span>
                               {% endif %}                                
                             </div>
                           </div>
@@ -275,11 +314,11 @@
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-addr-line-1-{{order_id}}-{{ shipment.id }}">{{ text_addr_line_1 }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3-sender-addr-line-1-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-sender-addr-line-1-{{order_id}}-{{ shipment.id }}" 
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][line1]" id="input-inpostoc3-sender-addr-line-1-{{order_id}}-{{ shipment.id }}" 
                               value="{{ shipment.sender_id ? shipment.sender.line1 : sender.line1 }}" 
                               placeholder="{{ text_addr_line_1 }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3-sender-addr-line-1-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.sender.line1 }}</span>
+                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][line1]" class="form-control">{{ shipment.sender.line1 }}</span>
                               {% endif %}                                
                             </div>
                           </div>
@@ -287,11 +326,11 @@
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-addr-line-2-{{order_id}}-{{ shipment.id }}">{{ text_addr_line_2 }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3-sender-addr-line-2-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-sender-addr-line-2-{{order_id}}-{{ shipment.id }}" 
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][line2]" id="input-inpostoc3-sender-addr-line-2-{{order_id}}-{{ shipment.id }}" 
                               value="{{ shipment.sender_id ? shipment.sender.line2 : sender.line2 }}" 
                               placeholder="{{ text_addr_line_2 }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3-sender-addr-line-2-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.sender.line2 }}</span>
+                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][line2]" class="form-control">{{ shipment.sender.line2 }}</span>
                               {% endif %}                                
                             </div>
                           </div>
@@ -299,11 +338,11 @@
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-addr-city-{{order_id}}-{{ shipment.id }}">{{ text_addr_city }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-sender-addr-city-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-sender-addr-city-{{order_id}}-{{ shipment.id }}" 
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][city]" id="input-inpostoc3-sender-addr-city-{{order_id}}-{{ shipment.id }}" 
                               value="{{ shipment.sender_id ? shipment.sender.city : sender.city }}" 
                               placeholder="{{ text_addr_city }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3-sender-addr-city-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.sender.city }}</span>
+                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][city]" class="form-control">{{ shipment.sender.city }}</span>
                               {% endif %}                               
                             </div>
                           </div>
@@ -311,19 +350,19 @@
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-addr-post-code-{{order_id}}-{{ shipment.id }}">{{ text_addr_post_code }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3-sender-addr-post-code-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-sender-addr-post-code-{{order_id}}-{{ shipment.id }}" 
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][post_code]" id="input-inpostoc3-sender-addr-post-code-{{order_id}}-{{ shipment.id }}" 
                               {{ sender_country_postcode_required ? 'required ' : '' }}
                               value="{{ shipment.sender_id ? shipment.sender.post_code : sender.post_code }}" 
                               placeholder="{{ text_addr_post_code }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3-sender-addr-post-code-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.sender.post_code }}</span>
+                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][post_code]" class="form-control">{{ shipment.sender.post_code }}</span>
                               {% endif %}                             
                             </div>
                           </div>
                           <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-addr-country-code-{{order_id}}-{{ shipment.id }}">{{ text_addr_country_code }}</label>
                             <div class="col-md-9">
-                              <span name="input-inpostoc3-sender-addr-country-code-{{order_id}}-{{ shipment.id }}" class="form-control" id="input-inpostoc3-sender-addr-country-code-{{order_id}}-{{ shipment.id }}">{{ shipment.sender.country_iso_code_2 }}</span>                             
+                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][country_iso_code_2]" class="form-control" id="input-inpostoc3-sender-addr-country-code-{{order_id}}-{{ shipment.id }}">{{ shipment.sender.country_iso_code_2 }}</span>                             
                             </div>
                           </div>
                         </td>
@@ -343,7 +382,7 @@
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-selected-point-{{order_id}}-{{ shipment.id }}">{{ text_selected_target_point }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="button" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3-receiver-selected-point-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-receiver-selected-point-{{order_id}}-{{ shipment.id }}" 
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][custom_attributes][target_point]" id="input-inpostoc3-receiver-selected-point-{{order_id}}-{{ shipment.id }}" 
                               value=
                               {% if shipment.custom_attributes.target_point is empty %}
                               "{{ text_click_to_select }}" 
@@ -355,7 +394,7 @@
                               {% endif %}
                               class="btn btn-primary form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3-receiver-selected-point-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.custom_attributes.target_point }}</span>
+                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][custom_attributes][target_point]" class="form-control">{{ shipment.custom_attributes.target_point }}</span>
                               {% endif %}                              
                             </div>
                           </div>
@@ -364,23 +403,31 @@
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-name-{{order_id}}-{{ shipment.id }}">{{ text_name }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-receiver-name-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-receiver-name-{{order_id}}-{{ shipment.id }}" 
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][name]" id="input-inpostoc3-receiver-name-{{order_id}}-{{ shipment.id }}" 
                               value="{{ shipment.receiver_id ? shipment.receiver.name : receiver.name }}" 
                               placeholder="{{ text_name }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3-receiver-name-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.receiver.name }}</span>
-                              {% endif %}     
+                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][name]" class="form-control">{{ shipment.receiver.name }}</span>
+                              {% endif %}
+                              {% if shipment.receiver_id %} 
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][id]" id="input-inpostoc3-receiver-id-{{order_id}}-{{ shipment.id }}"
+                              value="{{ shipment.receiver_id }}" >
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver_id]" id="input-inpostoc3-receiver_id-{{order_id}}-{{ shipment.id }}"
+                              value="{{ shipment.receiver_id }}" >
+                              {% endif %}    
                             </div>
                           </div>
                           <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-company-name-{{order_id}}-{{ shipment.id }}">{{ text_company_name }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3-receiver-company-name-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-receiver-company-name-{{order_id}}-{{ shipment.id }}" 
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][company_name]" id="input-inpostoc3-receiver-company-name-{{order_id}}-{{ shipment.id }}" 
                               value="{{ shipment.receiver_id ? shipment.receiver.company_name : receiver.company_name }}"
                               placeholder="{{ text_company_name }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3-receiver-company-name-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.receiver.company_name }}</span>
+                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][company_name]" class="form-control">{{ shipment.receiver.company_name }}</span>
                               {% endif %}                              
                             </div>
                           </div>
@@ -388,11 +435,11 @@
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-first-name-{{order_id}}-{{ shipment.id }}">{{ text_first_name }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-receiver-first-name-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-receiver-first-name-{{order_id}}-{{ shipment.id }}" 
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][first_name]" id="input-inpostoc3-receiver-first-name-{{order_id}}-{{ shipment.id }}" 
                               value="{{ shipment.receiver_id ? shipment.receiver.first_name : receiver.first_name }}"
                               placeholder="{{ text_first_name }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3-receiver-first-name-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.receiver.first_name }}</span>
+                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][first_name]" class="form-control">{{ shipment.receiver.first_name }}</span>
                               {% endif %}                              
                             </div>
                           </div>
@@ -400,11 +447,11 @@
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-last-name-{{order_id}}-{{ shipment.id }}">{{ text_last_name }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-receiver-last-name-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-receiver-last-name-{{order_id}}-{{ shipment.id }}" 
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][last_name]" id="input-inpostoc3-receiver-last-name-{{order_id}}-{{ shipment.id }}" 
                               value="{{ shipment.receiver_id ? shipment.receiver.last_name : receiver.last_name }}"
                               placeholder="{{ text_last_name }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3-receiver-last-name-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.receiver.last_name }}</span>
+                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][last_name]" class="form-control">{{ shipment.receiver.last_name }}</span>
                               {% endif %}                                  
                             </div>
                           </div>
@@ -412,11 +459,11 @@
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-phone-{{order_id}}-{{ shipment.id }}">{{ text_phone }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-receiver-phone-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-receiver-phone-{{order_id}}-{{ shipment.id }}" 
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][phone]" id="input-inpostoc3-receiver-phone-{{order_id}}-{{ shipment.id }}" 
                               value="{{ shipment.receiver_id ? shipment.receiver.phone : receiver.phone }}"
                               placeholder="{{ text_phone }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3-receiver-phone-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.receiver.phone }}</span>
+                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][phone]" class="form-control">{{ shipment.receiver.phone }}</span>
                               {% endif %}                         
                             </div>
                           </div>
@@ -424,11 +471,11 @@
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-email-{{order_id}}-{{ shipment.id }}">{{ text_email }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-receiver-email-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-receiver-email-{{order_id}}-{{ shipment.id }}" 
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][email]" id="input-inpostoc3-receiver-email-{{order_id}}-{{ shipment.id }}" 
                               value="{{ shipment.receiver_id ? shipment.receiver.email : receiver.email }}"
                               placeholder="{{ text_email }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3-receiver-email-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.receiver.email }}</span>
+                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][email]" class="form-control">{{ shipment.receiver.email }}</span>
                               {% endif %}                              
                             </div>                            
                           </div>
@@ -436,11 +483,11 @@
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-addr-street-{{order_id}}-{{ shipment.id }}">{{ text_addr_street }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-receiver-addr-street-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-receiver-addr-street-{{order_id}}-{{ shipment.id }}" 
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][street]" id="input-inpostoc3-receiver-addr-street-{{order_id}}-{{ shipment.id }}" 
                               value="{{ shipment.receiver_id ? shipment.receiver.street : receiver.street }}"
                               placeholder="{{ text_addr_street }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3-receiver-addr-street-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.receiver.street }}</span>
+                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][street]" class="form-control">{{ shipment.receiver.street }}</span>
                               {% endif %}                              
                             </div>
                           </div>
@@ -448,11 +495,11 @@
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-addr-building-number-{{order_id}}-{{ shipment.id }}">{{ text_addr_building_number }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-receiver-addr-building-number-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-receiver-addr-building-number-{{order_id}}-{{ shipment.id }}" 
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][building_number]" id="input-inpostoc3-receiver-addr-building-number-{{order_id}}-{{ shipment.id }}" 
                               value="{{ shipment.receiver_id ? shipment.receiver.building_number : receiver.building_number }}" 
                               placeholder="{{ text_addr_building_number }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3-receiver-addr-building-number-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.receiver.building_number }}</span>
+                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][building_number]" class="form-control">{{ shipment.receiver.building_number }}</span>
                               {% endif %}                                
                             </div>
                           </div>
@@ -460,11 +507,11 @@
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-addr-line-1-{{order_id}}-{{ shipment.id }}">{{ text_addr_line_1 }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3-receiver-addr-line-1-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-receiver-addr-line-1-{{order_id}}-{{ shipment.id }}" 
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][line1]" id="input-inpostoc3-receiver-addr-line-1-{{order_id}}-{{ shipment.id }}" 
                               value="{{ shipment.receiver_id ? shipment.receiver.line1 : receiver.line1 }}" 
                               placeholder="{{ text_addr_line_1 }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3-receiver-addr-line-1-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.receiver.line1 }}</span>
+                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][line1]" class="form-control">{{ shipment.receiver.line1 }}</span>
                               {% endif %}                                
                             </div>
                           </div>
@@ -472,11 +519,11 @@
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-addr-line-2-{{order_id}}-{{ shipment.id }}">{{ text_addr_line_2 }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3-receiver-addr-line-2-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-receiver-addr-line-2-{{order_id}}-{{ shipment.id }}" 
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][line2]" id="input-inpostoc3-receiver-addr-line-2-{{order_id}}-{{ shipment.id }}" 
                               value="{{ shipment.receiver_id ? shipment.receiver.line2 : receiver.line2 }}" 
                               placeholder="{{ text_addr_line_2 }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3-receiver-addr-line-2-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.receiver.line2 }}</span>
+                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][line2]" class="form-control">{{ shipment.receiver.line2 }}</span>
                               {% endif %}                                
                             </div>
                           </div>
@@ -484,11 +531,11 @@
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-addr-city-{{order_id}}-{{ shipment.id }}">{{ text_addr_city }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3-receiver-addr-city-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-receiver-addr-city-{{order_id}}-{{ shipment.id }}" 
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" required name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][city]" id="input-inpostoc3-receiver-addr-city-{{order_id}}-{{ shipment.id }}" 
                               value="{{ shipment.receiver_id ? shipment.receiver.city :  receiver.city }}" 
                               placeholder="{{ text_addr_city }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3-receiver-addr-city-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.receiver.city }}</span>
+                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][city]" class="form-control">{{ shipment.receiver.city }}</span>
                               {% endif %}                               
                             </div>
                           </div>
@@ -496,19 +543,19 @@
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-addr-post-code-{{order_id}}-{{ shipment.id }}">{{ text_addr_post_code }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
-                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3-receiver-addr-post-code-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-receiver-addr-post-code-{{order_id}}-{{ shipment.id }}" 
+                              <input type="text" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][post_code]" id="input-inpostoc3-receiver-addr-post-code-{{order_id}}-{{ shipment.id }}" 
                               value="{{ shipment.receiver_id ? shipment.receiver.post_code : receiver.post_code }}" 
                               {{ sender_country_postcode_required ? 'required ' : '' }}
                               placeholder="{{ text_addr_post_code }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3-receiver-addr-post-code-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.receiver.post_code }}</span>
+                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][post_code]" class="form-control">{{ shipment.receiver.post_code }}</span>
                               {% endif %}                             
                             </div>
                           </div>
                           <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-addr-country-code-{{order_id}}-{{ shipment.id }}">{{ text_addr_country_code }}</label>
                             <div class="col-md-9">
-                              <span name="input-inpostoc3-receiver-addr-country-code-{{order_id}}-{{ shipment.id }}" id="input-inpostoc3-receiver-addr-country-code-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.receiver.country_iso_code_2 }}</span>                             
+                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][country_iso_code_2]" id="input-inpostoc3-receiver-addr-country-code-{{order_id}}-{{ shipment.id }}" class="form-control">{{ shipment.receiver.country_iso_code_2 }}</span>                             
                             </div>
                           </div>
                         </td>
@@ -542,7 +589,7 @@
                         <td class="text-left">
                           <div class="form-group row form-inline" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <div class="col-md-12">
-                              <select  name="input-inpostoc3-parcel-{{order_id}}-{{ shipment.id }}-{{ parcel.id }}" id="input-inpostoc3-parcel-{{order_id}}-{{ shipment.id }}-{{ parcel.id }}" class="form-control" style="width: 100%;">
+                              <select form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][parcels][{{ parcel.id }}][template_id]" id="input-inpostoc3-parcel-{{ parcel.id }}-template-id-{{order_id}}-{{ shipment.id }}" class="form-control" style="width: 100%;">
                               <option value="0"
                               {% if not parcel.id %}
                               selected="selected"
@@ -554,9 +601,15 @@
                               {% if parcel.template_id is same as (parcel_template.id) %}
                               selected="selected"
                               {% endif %}
-                              >{{ parcel_template.template_identifier }}</option>
+                              >{{ parcel_template.template_identifier }} - {{ parcel_template.max_height}}mm x {{ parcel_template.max_width}}mm x {{ parcel_template.max_length}}mm x {{ parcel_template.max_weight}}kg </option>
                               {% endfor %}
                               </select>
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][parcels][{{ parcel.id }}][id]" id="input-inpostoc3-parcel-{{parcel.id}}-id-{{order_id}}-{{ shipment.id }}"
+                              value="{{ parcel.id }}" >
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][parcels][{{ parcel.id }}][shipment_id]" id="input-inpostoc3-parcel-{{parcel.id}}-shipment_id-{{order_id}}-{{ shipment.id }}"
+                              value="{{ shipment.id }}" >
                             </div>
                           </div>
                         </td>
@@ -574,6 +627,18 @@
                   </table>
                 </td>
               </tr>
+              <tr>
+                <td colspan="2" class="text-center">
+                  <div class="pull-center">
+                    <button type="submit" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" data-toggle="tooltip" title="{{ button_shipping_save }}" class="btn btn-primary" formaction="{{ action_save }}" data-original-title="Save"><i class="fa fa-save"></i></button> 
+                    <button type="submit" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" data-toggle="tooltip" title="{{ button_shipping_print }}" class="btn btn-primary" formaction=""><i class="fa fa-truck"></i></button>
+                    {% if shipment.can_edit.sending_method_details %}
+                    <form method="post" enctype="multipart/form-data" id="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" class="col-md-12">
+                    </form>
+                    {% endif %}
+                  </div>
+                </td>
+              </tr>
             </tbody>
           </table>
 
@@ -583,10 +648,7 @@
       </div>
     </div>
 
-    {% if inpostoc3_can_edit.shipment %}
-    <form method="post" enctype="multipart/form-data" id="form-inpostoc3-order-shipping-{{ order_id }}" class="col-md-12">
-    </form>
-    {% endif %}
+    
 
     {% endif %}
   </div>

--- a/upload/admin/view/template/extension/shipping/inpostoc3_order_shipping.twig
+++ b/upload/admin/view/template/extension/shipping/inpostoc3_order_shipping.twig
@@ -67,7 +67,11 @@
                       {% set dropoff_enable = false %}
                       <tr>
                         <td>
-                        <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
+                        <div class="form-group row form-inline 
+                        {% if shipment.can_edit.sending_method_details %}
+                        required
+                        {% endif %}
+                        " style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                           <label class="col-md-2 control-label" for="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}">{{ text_service }}</label>
                           <div class="col-md-10">
                             {% if shipment.can_edit.sending_method_details %}
@@ -87,6 +91,12 @@
                             </select>
                             {% else %}
                             {{ attribute(_context,'text_' ~shipment.service_identifier~'_name')  }}
+                            <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][service_id]" id="input-inpostoc3-service-{{order_id}}-{{ shipment.id }}"
+                              value="{{ shipment.service_id }}" >
+                            <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][service_identifier]" id="input-inpostoc3-service_identifier-{{order_id}}-{{ shipment.id }}"
+                              value="{{ shipment.service_identifier }}" >
                             {% endif %}
                             <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
                               name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][id]" id="input-inpostoc3-shipment-id-{{order_id}}-{{ shipment.id }}"
@@ -99,7 +109,11 @@
                               value="{{ order_id }}" >
                           </div>
                         </div>
-                        <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
+                        <div class="form-group row form-inline 
+                        {% if shipment.can_edit.sending_method_details %}
+                        required
+                        {% endif %}
+                        " style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                           <label class="col-md-2 control-label" for="input-inpostoc3-sending-method-{{order_id}}-{{ shipment.id }}">{{ text_sending_method }}</label>
                           <div class="col-md-10">
                             {% if shipment.can_edit.sending_method_details %}
@@ -127,7 +141,15 @@
                               <!-- after initial fill do the java script stuff here to fill sending methods according to selected service -->              
                             </select>
                             {% else %}
-                            {{ attribute(_context,'text_' ~shipment.custom_attributes.sending_method~'_name')  }}
+                            {% if shipment.custom_attributes.sending_method %}
+                            {{ attribute(_context,'text_sending_method_' ~shipment.custom_attributes.sending_method_identifier) }}
+                            <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" 
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][custom_attributes][sending_method]" id="input-inpostoc3-sending-method-{{order_id}}-{{ shipment.id }}" 
+                              value="{{ shipment.custom_attributes.sending_method }}" >
+                            <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" 
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][custom_attributes][sending_method_identifier]" id="input-inpostoc3-sending-method_identifier-{{order_id}}-{{ shipment.id }}" 
+                              value="{{ shipment.custom_attributes.sending_method_identifier }}" >
+                            {% endif %}
                             {% endif %}
                             <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" 
                             name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][custom_attributes][shipment_id]" id="input-inpostoc3-shipment-cattr-shipment_id-{{order_id}}-{{ shipment.id }}" 
@@ -136,7 +158,7 @@
                             <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}" 
                             name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][custom_attributes][id]" id="input-inpostoc3-shipment-cattr-{{ shipment.custom_attributes.id }}-id-{{order_id}}-{{ shipment.id }}" 
                               value="{{ shipment.custom_attributes.id }}" >
-                              {% endif %}
+                            {% endif %}
                           </div>
                         </div>
                         </td>
@@ -167,7 +189,10 @@
                               {% endif %}
                               class="btn btn-primary form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][custom_attributes][dropoff_point]" class="form-control">{{ shipment.custom_attributes.dropoff_point }}</span>
+                                {{ shipment.custom_attributes.dropoff_point }}
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][custom_attributes][dropoff_point]" id="input-inpostoc3-sender-selected-point-{{order_id}}-{{ shipment.id }}"
+                              value="{{ shipment.custom_attributes.dropoff_point }}" >
                               {% endif %}                              
                             </div>
                           </div>
@@ -195,7 +220,11 @@
 						              {% endif %}
 
 
-                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
+                          <div class="form-group row form-inline 
+                          {% if shipment.can_edit.sending_method_details %}
+                          required
+                          {% endif %}
+                          " style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-sender-name-{{order_id}}-{{ shipment.id }}">{{ text_name }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -203,7 +232,10 @@
                               value="{{ shipment.sender_id ? shipment.sender.name : sender.name }}"
                               placeholder="{{ text_name }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3-{{order_id}}-{{ shipment.id }}-sender-name" class="form-control">{{ shipment.sender.name }}</span>
+                              {{ shipment.sender.name }}
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][sender][name]" id="input-inpostoc3-sender-name-{{order_id}}-{{ shipment.id }}"
+                              value="{{ shipment.sender.name }}" >
                               {% endif %}
                               {% if shipment.sender_id %}
                               <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
@@ -416,12 +448,19 @@
                               {% endif %}
                               class="btn btn-primary form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][custom_attributes][target_point]" class="form-control">{{ shipment.custom_attributes.target_point }}</span>
+                                {{ shipment.custom_attributes.target_point }}
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][custom_attributes][target_point]" id="input-inpostoc3-receiver-selected-point-{{order_id}}-{{ shipment.id }}"
+                              value="{{ shipment.custom_attributes.target_point }}" >
                               {% endif %}                              
                             </div>
                           </div>
 
-                          <div class="form-group row form-inline required" style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
+                          <div class="form-group row form-inline 
+                          {% if shipment.can_edit.sending_method_details %}
+                          required
+                          {% endif %}
+                          " style="border-top: 0px; padding-top: 5px; padding-bottom: 5px;">
                             <label class="col-md-3 control-label" for="input-inpostoc3-receiver-name-{{order_id}}-{{ shipment.id }}">{{ text_name }}</label>
                             <div class="col-md-9">
                               {% if shipment.can_edit.sending_method_details %}
@@ -429,7 +468,10 @@
                               value="{{ shipment.receiver_id ? shipment.receiver.name : receiver.name }}" 
                               placeholder="{{ text_name }}"  class="form-control" style="width: 100%;" />
                               {% else %}
-                              <span name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][name]" class="form-control">{{ shipment.receiver.name }}</span>
+                              {{ shipment.receiver.name }}
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][receiver][name]" id="input-inpostoc3-receiver-name-{{order_id}}-{{ shipment.id }}"
+                              value="{{ shipment.receiver.name }}" >
                               {% endif %}
                               {% if shipment.receiver_id %} 
                               <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
@@ -663,12 +705,13 @@
                               {% else %}
                               {% for parcel_template in parcel_templates %}
                               {% if parcel.template_id is same as (parcel_template.id) %}
-                              <span class="form-control"
-                                name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][parcels][{{ parcel.id }}][template_id]" 
-                                id="input-inpostoc3-parcel-{{ parcel.id }}-template-id-{{order_id}}-{{ shipment.id }}"
-                              >
                                 {{ parcel_template.template_identifier }} - {{ parcel_template.max_height}}mm x {{ parcel_template.max_width}}mm x {{ parcel_template.max_length}}mm x {{ parcel_template.max_weight}}kg
-                              </span>
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][parcels][{{ parcel.id }}][template_id]" id="input-inpostoc3-parcel-{{ parcel.id }}-template-id-{{order_id}}-{{ shipment.id }}"
+                              value="{{ parcel.template_id }}" >
+                              <input type="hidden" form="form-inpostoc3-order-shipping-{{ order_id }}-{{ shipment.id }}"
+                              name="input-inpostoc3[{{order_id}}][shipments][{{ shipment.id }}][parcels][{{ parcel.id }}][template_identifier]" id="input-inpostoc3-parcel-{{ parcel.id }}-template-identifier-{{order_id}}-{{ shipment.id }}"
+                              value="{{ parcel.template_identifier }}" >
                               {% endif %}
                               {% endfor %}
                               {% endif %}

--- a/upload/catalog/view/javascript/inpostoc3.js
+++ b/upload/catalog/view/javascript/inpostoc3.js
@@ -8,7 +8,7 @@ const geoWidgetStyleSrc = '<link rel=\"stylesheet\" href=\"https://geowidget.eas
 $(document).ready(function() {  
 
   $(geoWidgetScriptSrc).appendTo('head');
-$(geoWidgetStyleSrc).insertAfter('#' + geoWidgetSrcId);
+  $(geoWidgetStyleSrc).insertAfter('#' + geoWidgetSrcId);
 
 const ipoc3 = new InPostOC3('inpostoc3-geowidget');
 try {


### PR DESCRIPTION
### What was the problem?

1. No UI in admin part to manage details of shipment necessary for e.g. sending via parcel_locker.
2. No data saved in DB in format making it easy to make subsequent API calls to ShipX API.

### Solution

Additonal OrderShipping view (displayed as part of the order), enabled only if
* Inpost API integration is enabled
* admin part user clicks on 'dispatch' button (truck icon) in order details view

A form with input fields. Order has atm 1 shipment, but it's easy to add functionality to add shipments in the future.

**Sender** 

Once sender is saved, it can be re-used in future by selecting Name from dropdown. Added geowidget to name the parcel locker, where the shipment will be posted.

**Receiver**

Taken from order data, yet can be edited; added geowidget for parcel locker selection change

**Sending details:**

* service - just parcel locker service atm (which triggers 1 shipment - 1 parcel dependency)
* sending method - just send via parcel locker atm (todo: dispatch via courier)

No additional services yet (insurances etc).

**Parcels**

Predefined parcel template may be used as of now. Improtant for price of the shipment and when sending to parcel lockers (InPost will charge for misdeclared parcel templates).

### What is not done:

1. Front-end validations
2. Getting label
3. Enlisting products in parcel (though data for that ready in controller)
4. Full cleanup from comments in source (to do at the end of the work)

### Glossary

- Shipment - an overall shipment entity. Shipment may have multiple parcels, always must have a sender and receiver (plus additonal 
- Parcel - a physical package, consignment
- Label - a dispatch note, which courier system can understand and helps to route from sender to the receiver, required to ship
- Route, routing - route from sender to receiver, here less important (country wide domestic service, with no exceptions for regions yet)